### PR TITLE
Nullable Enums and CreateInstance/CreateSet

### DIFF
--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SituationalTests/NullableEnumTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SituationalTests/NullableEnumTests.cs
@@ -28,5 +28,24 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.SituationalTests
             var test = table.CreateInstance<TestEntity>();
             test.TestProperty.Should().Be(TestEnum.Value2);
         }
+
+        [Test]
+        public void The_value_should_be_NULL_if_it_is_not_filled_in_the_table()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("TestProperty", "");
+
+            var test = table.CreateInstance<TestEntity>();
+            test.TestProperty.Should().BeNull();
+        }
+
+        [Test]
+        public void The_value_should_be_NULL_if_it_is_not_in_the_table()
+        {
+            var table = new Table("Field", "Value");
+
+            var test = table.CreateInstance<TestEntity>();
+            test.TestProperty.Should().BeNull();
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SituationalTests/NullableEnumTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SituationalTests/NullableEnumTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist;
 
@@ -46,6 +47,17 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.SituationalTests
 
             var test = table.CreateInstance<TestEntity>();
             test.TestProperty.Should().BeNull();
+        }
+
+        [Test]
+        public void There_should_be_an_error_if_in_the_table_is_no_valid_Enum_value()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("TestProperty", "NotAnEnumValue");
+
+            Action x = () => { table.CreateInstance<TestEntity>(); };
+
+            x.ShouldThrow<InvalidOperationException>();
         }
     }
 }


### PR DESCRIPTION
Fix support for nullable enums in CreateInstance/CreateSet.

I am not completly sure how the method should be behave, if in the table is an invalid Enum value. Should the result be null or should it throw an exception?
See the test `TechTalk.SpecFlow.RuntimeTests.AssistTests.SituationalTests.NullableEnumTests.There_should_be_an_error_if_in_the_table_is_no_valid_Enum_value()`