### PR TITLE
Added scenarios with long hooks

### DIFF
--- a/Tests/TechTalk.SpecFlow.Specs/Features/Hooks/HookSupport.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Hooks/HookSupport.feature
@@ -31,6 +31,37 @@ Examples: Cucumber compatibility
 	| Before |
 	| After  |
 
+Scenario Outline: Should execute SpecFlow events and wait them
+	Given a scenario 'Simple Scenario' as
+         """
+	     When I do something
+         """
+	And a hook 'HookFor<event>' for '<event>' with code
+	     """
+	     System.Threading.Thread.Sleep(2000);
+	     """
+	And all steps are bound and pass
+	When I execute the tests
+	Then the hook 'HookFor<event>' is executed once
+
+Examples: 
+	| event               |
+	| BeforeScenario      |
+	| AfterScenario       |
+	| BeforeFeature       |
+	| AfterFeature        |
+	| BeforeStep          |
+	| AfterStep           |
+	| BeforeScenarioBlock |
+	| AfterScenarioBlock  |
+	| BeforeTestRun       |
+	| AfterTestRun        |
+
+Examples: Cucumber compatibility
+	| event  |
+	| Before |
+	| After  |
+
 Scenario Outline: Should execute the hooks according to their semantics
 	Given there is a feature file in the project as
         """

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/BindingSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/BindingSteps.cs
@@ -125,6 +125,12 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
             _projectsDriver.AddHookBinding(eventType, methodName, order: hookOrder);
         }
 
+        [Given(@"a hook '(.*)' for '([^']*)' with code")]
+        public void GivenAHookForWithCode(string methodName, string eventType, string code)
+        {
+            _projectsDriver.AddHookBinding(eventType, methodName, code: code);
+        }
+
         [Given(@"the following binding class")]
         [Given(@"the following class")]
         public void GivenTheFollowingBindingClass(string rawBindingClass)


### PR DESCRIPTION
Added scenarios with hooks. Hook just wait couple of seconds to make sure that execution engine really executes hooks and wait them.

Some netcore tests should fail. This PR is created to highlight the [issue](https://github.com/techtalk/SpecFlow/issues/1348)