### PR TITLE
Add CompareToSuperSet method

### DIFF
--- a/Runtime/Assist/SetComparer.cs
+++ b/Runtime/Assist/SetComparer.cs
@@ -40,6 +40,16 @@ namespace TechTalk.SpecFlow.Assist
             AssertThatNoExtraRowsExist(set, GetListOfExpectedItemsThatCouldNotBeFound(set));
         }
 
+        public void CompareToSuperSet(IEnumerable<T> superset)
+        {
+            AssertThatAllColumnsInTheTableMatchToPropertiesOnTheType();
+
+            if (ThereAreNoResultsAndNoExpectedResults(superset))
+                return;
+
+            AssertThatTheItemsMatchTheExpectedResults(superset);
+        }
+
         private void AssertThatNoExtraRowsExist(IEnumerable<T> set, IEnumerable<int> listOfMissingItems)
         {
             if (set.Count() == table.Rows.Count()) return;

--- a/Runtime/Assist/SetComparisonExtensionMethods.cs
+++ b/Runtime/Assist/SetComparisonExtensionMethods.cs
@@ -9,5 +9,11 @@ namespace TechTalk.SpecFlow.Assist
             var checker = new SetComparer<T>(table);
             checker.CompareToSet(set);
         }
+        public static void CompareToSuperSet<T>(this Table table, IEnumerable<T> superSet)
+        {
+            var checker = new SetComparer<T>(table);
+            checker.CompareToSuperSet(superSet);
+        }
+
     }
 }


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Add a CompareToSuperset which confirms the incoming IEnumerable is a superset of the table the SetComparer is initialized with.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
