### PR TITLE
Added msbuild target to automatically copy config file to output

### DIFF
--- a/TechTalk.SpecFlow/SpecFlow.nuspec
+++ b/TechTalk.SpecFlow/SpecFlow.nuspec
@@ -56,6 +56,8 @@
 
     <file src="$SolutionDir$LICENSE.txt" target="LICENSE.txt" />
 
+    <file src="SpecFlow.targets" target="build\SpecFlow.targets" />
+
   </files>
 
 </package>

--- a/TechTalk.SpecFlow/SpecFlow.targets
+++ b/TechTalk.SpecFlow/SpecFlow.targets
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_SpecFlow_CopyConfigJsonFile" AfterTargets="BeforeBuild" Condition=" Exists('specflow.json') ">
+    <ItemGroup>
+      <None Include="specflow.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Added target into nuget package. This allows to automatically copy `specflow.json` file into output folder. So user is not required to change properties for this file.

Any project with installed SpecFlow nuget package gets this feature as build in feature.