### PR TITLE
Added GenerateCodeAttribute to AssemblyHooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -386,6 +386,8 @@ GitExtensions.settings.backup
 /Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/Features/dummy.feature.cs
 *.feature.cs
 /Tests/TechTalk.SpecFlow.Specs/Features/CucumberMessages
+*.AssemblyHooks.cs
+*.AssemblyHooks.vb
 
 # Nerdbank.GitVersioning
 Tests/TechTalk.SpecFlow.Specs/NuGetPackageVersion.cs

--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/SpecFlow.MSTest.nuspec
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/SpecFlow.MSTest.nuspec
@@ -21,7 +21,7 @@
   </metadata>
 
   <files>
-    <file src="build\**\*" target="build" />
+    <file src="build\**\*" exclude="build\*.template.*" target="build" />
     <file src="bin\$config$\net471\TechTalk.SpecFlow.MSTest.SpecFlowPlugin.*" target="lib\$SpecFlow_FullFramework_Runtime_TFM$" />
     <file src="bin\$config$\netstandard2.0\TechTalk.SpecFlow.MSTest.SpecFlowPlugin.dll" target="lib\$SpecFlow_Core_Runtime_TFM$" />
     <file src="bin\$config$\netstandard2.0\TechTalk.SpecFlow.MSTest.SpecFlowPlugin.pdb" target="lib\$SpecFlow_Core_Runtime_TFM$" />

--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin.csproj
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin.csproj
@@ -12,14 +12,15 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="build\MSTest.AssemblyHooks.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="build\MSTest.AssemblyHooks.cs" />
+    <Compile Remove="build\MSTest.AssemblyHooks.template.cs" />
+    <Compile Remove="build\MSTest.AssemblyHooks.template.vb" />
+    <None Include="build\MSTest.AssemblyHooks.template.cs" />
+    <None Include="build\MSTest.AssemblyHooks.template.vb" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.AdditionalTasks" Version="0.1.35" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,4 +29,14 @@
     <ProjectReference Include="..\TechTalk.SpecFlow.MSTest.SpecFlowPlugin\TechTalk.SpecFlow.MSTest.SpecFlowPlugin.csproj" />
   </ItemGroup>
 
+  <Target Name="WriteAssemblyHooksVersion" AfterTargets="GetBuildVersion" BeforeTargets="BeforeCompile" Condition="$(DesignTimeBuild) != 'true' or '$(BuildingProject)' == 'true'">
+    <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.template.cs" OutputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.cs" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
+    <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.template.vb" OutputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.vb" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
+
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.cs" />
+      <None Include="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.vb" />
+    </ItemGroup>
+  </Target>
+  
 </Project>

--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin.csproj
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin.csproj
@@ -12,10 +12,8 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="build\MSTest.AssemblyHooks.template.cs" />
-    <Compile Remove="build\MSTest.AssemblyHooks.template.vb" />
-    <None Include="build\MSTest.AssemblyHooks.template.cs" />
-    <None Include="build\MSTest.AssemblyHooks.template.vb" />
+    <Compile Remove="build\**\*" />
+    <None Include="build\**\*" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,11 +30,6 @@
   <Target Name="WriteAssemblyHooksVersion" AfterTargets="GetBuildVersion" BeforeTargets="BeforeCompile" Condition="$(DesignTimeBuild) != 'true' or '$(BuildingProject)' == 'true'">
     <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.template.cs" OutputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.cs" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
     <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.template.vb" OutputFile="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.vb" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
-
-    <ItemGroup>
-      <None Include="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.cs" />
-      <None Include="$(MSBuildThisFileDirectory)\build\MSTest.AssemblyHooks.vb" />
-    </ItemGroup>
   </Target>
   
 </Project>

--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/MSTest.AssemblyHooks.template.cs
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/MSTest.AssemblyHooks.template.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
+using System.CodeDom.Compiler;
 using global::Microsoft.VisualStudio.TestTools.UnitTesting;
 using global::TechTalk.SpecFlow;
 
+[GeneratedCode("SpecFlow", "SPECFLOW_VERSION")]
 [TestClass]
 public class PROJECT_ROOT_NAMESPACE_MSTestAssemblyHooks
 {

--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/MSTest.AssemblyHooks.template.vb
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/MSTest.AssemblyHooks.template.vb
@@ -2,8 +2,9 @@
 Imports TechTalk.SpecFlow
 Imports System
 Imports System.Reflection
+Imports System.CodeDom.Compiler
 
-
+<GeneratedCode("SpecFlow", "SPECFLOW_VERSION")>
 <TestClass>
 Public NotInheritable Class PROJECT_ROOT_NAMESPACE_MSTestAssemblyHooks
     <AssemblyInitialize>

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/SpecFlow.NUnit.nuspec
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/SpecFlow.NUnit.nuspec
@@ -21,7 +21,7 @@
   </metadata>
 
   <files>
-    <file src="build\**\*" target="build" />
+    <file src="build\**\*" exclude="build\*.template.*" target="build" />
     <file src="bin\$config$\net471\TechTalk.SpecFlow.NUnit.SpecFlowPlugin.*" target="lib\$SpecFlow_FullFramework_Runtime_TFM$" />
     <file src="bin\$config$\netstandard2.0\TechTalk.SpecFlow.NUnit.SpecFlowPlugin.dll" target="lib\$SpecFlow_Core_Runtime_TFM$" />
     <file src="bin\$config$\netstandard2.0\TechTalk.SpecFlow.NUnit.SpecFlowPlugin.pdb" target="lib\$SpecFlow_Core_Runtime_TFM$" />

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin.csproj
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin.csproj
@@ -12,14 +12,15 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="build\NUnit.AssemblyHooks.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="build\NUnit.AssemblyHooks.cs" />
+    <Compile Remove="build\NUnit.AssemblyHooks.template.cs" />
+    <Compile Remove="build\NUnit.AssemblyHooks.template.vb" />
+    <None Include="build\NUnit.AssemblyHooks.template.cs" />
+    <None Include="build\NUnit.AssemblyHooks.template.vb" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.AdditionalTasks" Version="0.1.35" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,4 +29,14 @@
     <ProjectReference Include="..\TechTalk.SpecFlow.NUnit.SpecFlowPlugin\TechTalk.SpecFlow.NUnit.SpecFlowPlugin.csproj" />
   </ItemGroup>
 
+  <Target Name="WriteAssemblyHooksVersion" AfterTargets="GetBuildVersion" BeforeTargets="BeforeCompile" Condition="$(DesignTimeBuild) != 'true' or '$(BuildingProject)' == 'true'">
+    <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.template.cs" OutputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.cs" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
+    <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.template.vb" OutputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.vb" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
+
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.cs" />
+      <None Include="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.vb" />
+    </ItemGroup>
+  </Target>
+  
 </Project>

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin.csproj
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin.csproj
@@ -12,10 +12,8 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="build\NUnit.AssemblyHooks.template.cs" />
-    <Compile Remove="build\NUnit.AssemblyHooks.template.vb" />
-    <None Include="build\NUnit.AssemblyHooks.template.cs" />
-    <None Include="build\NUnit.AssemblyHooks.template.vb" />
+    <Compile Remove="build\**\*" />
+    <None Include="build\**\*" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,11 +30,6 @@
   <Target Name="WriteAssemblyHooksVersion" AfterTargets="GetBuildVersion" BeforeTargets="BeforeCompile" Condition="$(DesignTimeBuild) != 'true' or '$(BuildingProject)' == 'true'">
     <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.template.cs" OutputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.cs" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
     <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.template.vb" OutputFile="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.vb" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
-
-    <ItemGroup>
-      <None Include="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.cs" />
-      <None Include="$(MSBuildThisFileDirectory)\build\NUnit.AssemblyHooks.vb" />
-    </ItemGroup>
   </Target>
   
 </Project>

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/NUnit.AssemblyHooks.template.cs
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/NUnit.AssemblyHooks.template.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
+using System.CodeDom.Compiler;
 using global::NUnit.Framework;
 using global::TechTalk.SpecFlow;
 
+[GeneratedCode("SpecFlow", "SPECFLOW_VERSION")]
 [SetUpFixture]
 public class PROJECT_ROOT_NAMESPACE_NUnitAssemblyHooks
 {

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/NUnit.AssemblyHooks.template.vb
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/NUnit.AssemblyHooks.template.vb
@@ -1,8 +1,10 @@
 ﻿Imports NUnit.Framework
 Imports TechTalk.SpecFlow
 Imports System
+Imports System.CodeDom.Compiler
 Imports System.Reflection
 
+<GeneratedCode("SpecFlow", "SPECFLOW_VERSION")>
 <SetUpFixture>
 Public NotInheritable Class PROJECT_ROOT_NAMESPACE_NUnitAssemblyHooks
     <OneTimeSetUp>

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/SpecFlow.xUnit.nuspec
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/SpecFlow.xUnit.nuspec
@@ -22,7 +22,7 @@
   </metadata>
 
   <files>
-    <file src="build\**\*" target="build" />
+    <file src="build\**\*" exclude="build\*.template.*" target="build" />
     <file src="bin\$config$\net471\TechTalk.SpecFlow.xUnit.SpecFlowPlugin.*" target="lib\net452" />
     <file src="bin\$config$\netstandard2.0\TechTalk.SpecFlow.xUnit.SpecFlowPlugin.dll" target="lib\$SpecFlow_Core_Runtime_TFM$" />
     <file src="bin\$config$\netstandard2.0\TechTalk.SpecFlow.xUnit.SpecFlowPlugin.pdb" target="lib\$SpecFlow_Core_Runtime_TFM$" />

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj
@@ -12,14 +12,15 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="build\xUnit.AssemblyHooks.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="build\xUnit.AssemblyHooks.cs" />
+    <Compile Remove="build\xUnit.AssemblyHooks.template.cs" />
+    <Compile Remove="build\xUnit.AssemblyHooks.template.vb" />
+    <None Include="build\xUnit.AssemblyHooks.template.cs" />
+    <None Include="build\xUnit.AssemblyHooks.template.vb" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.AdditionalTasks" Version="0.1.35" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,5 +28,15 @@
     <ProjectReference Include="..\..\TechTalk.SpecFlow\TechTalk.SpecFlow.csproj" />
     <ProjectReference Include="..\TechTalk.SpecFlow.xUnit.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.SpecFlowPlugin.csproj" />
   </ItemGroup>
+
+  <Target Name="WriteAssemblyHooksVersion" AfterTargets="GetBuildVersion" BeforeTargets="BeforeCompile" Condition="$(DesignTimeBuild) != 'true' or '$(BuildingProject)' == 'true'">
+    <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.template.cs" OutputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.cs" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
+    <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.template.vb" OutputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.vb" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
+
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.cs" />
+      <None Include="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.vb" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj
@@ -12,10 +12,8 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="build\xUnit.AssemblyHooks.template.cs" />
-    <Compile Remove="build\xUnit.AssemblyHooks.template.vb" />
-    <None Include="build\xUnit.AssemblyHooks.template.cs" />
-    <None Include="build\xUnit.AssemblyHooks.template.vb" />
+    <Compile Remove="build\**\*" />
+    <None Include="build\**\*" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,10 +31,6 @@
     <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.template.cs" OutputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.cs" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
     <ReplaceTextInFileTask InputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.template.vb" OutputFile="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.vb" TextToReplace="SPECFLOW_VERSION" TextToReplaceWith="$(NuGetPackageVersion)" />
 
-    <ItemGroup>
-      <None Include="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.cs" />
-      <None Include="$(MSBuildThisFileDirectory)\build\xUnit.AssemblyHooks.vb" />
-    </ItemGroup>
   </Target>
 
 </Project>

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/xUnit.AssemblyHooks.template.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/xUnit.AssemblyHooks.template.cs
@@ -1,6 +1,9 @@
-﻿[assembly: global::Xunit.TestFramework("TechTalk.SpecFlow.xUnit.SpecFlowPlugin.XunitTestFrameworkWithAssemblyFixture", "TechTalk.SpecFlow.xUnit.SpecFlowPlugin")]
+﻿using System.CodeDom.Compiler;
+
+[assembly: global::Xunit.TestFramework("TechTalk.SpecFlow.xUnit.SpecFlowPlugin.XunitTestFrameworkWithAssemblyFixture", "TechTalk.SpecFlow.xUnit.SpecFlowPlugin")]
 [assembly: global::TechTalk.SpecFlow.xUnit.SpecFlowPlugin.AssemblyFixture(typeof(global::PROJECT_ROOT_NAMESPACE_XUnitAssemblyFixture))]
 
+[GeneratedCode("SpecFlow", "SPECFLOW_VERSION")]
 public class PROJECT_ROOT_NAMESPACE_XUnitAssemblyFixture : global::System.IDisposable
 {
     private readonly global::System.Reflection.Assembly _currentAssembly;

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/xUnit.AssemblyHooks.template.vb
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/xUnit.AssemblyHooks.template.vb
@@ -1,6 +1,9 @@
-﻿<Assembly: Global.Xunit.TestFramework("TechTalk.SpecFlow.xUnit.SpecFlowPlugin.XunitTestFrameworkWithAssemblyFixture", "TechTalk.SpecFlow.xUnit.SpecFlowPlugin")>
+﻿Imports System.CodeDom.Compiler
+
+<Assembly: Global.Xunit.TestFramework("TechTalk.SpecFlow.xUnit.SpecFlowPlugin.XunitTestFrameworkWithAssemblyFixture", "TechTalk.SpecFlow.xUnit.SpecFlowPlugin")>
 <Assembly: Global.TechTalk.SpecFlow.xUnit.SpecFlowPlugin.AssemblyFixture(GetType(PROJECT_ROOT_NAMESPACE_XUnitAssemblyFixture))>
 
+<GeneratedCode("SpecFlow", "SPECFLOW_VERSION")>
 Public Class PROJECT_ROOT_NAMESPACE_XUnitAssemblyFixture
     Implements Global.System.IDisposable
 

--- a/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.csproj
@@ -4,19 +4,24 @@
     manual import sdk to be able to simulate nuget based imports
   -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  
   <Import Project="..\..\SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.props" />
 
   <PropertyGroup>
     <TargetFramework>$(SpecFlow_Core_Specs_TFM)</TargetFramework>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
+    <SpecFlow_DeleteCodeBehindFilesOnCleanRebuild>true</SpecFlow_DeleteCodeBehindFilesOnCleanRebuild>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <_SpecFlow_TaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' And '$(_SpecFlow_TaskFolder)' == ''">netcoreapp2.0</_SpecFlow_TaskFolder>
-    <_SpecFlow_TaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' And '$(_SpecFlow_TaskFolder)' == ''">net471</_SpecFlow_TaskFolder>
-    <_SpecFlow_TaskAssembly>..\..\SpecFlow.Tools.MsBuild.Generation\bin\$(Configuration)\$(_SpecFlow_TaskFolder)\SpecFlow.Tools.MsBuild.Generation.dll</_SpecFlow_TaskAssembly>
-  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj" />
+    <ProjectReference Include="..\..\Plugins\TechTalk.SpecFlow.xUnit.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.SpecFlowPlugin.csproj" />
+    <ProjectReference Include="..\..\TechTalk.SpecFlow\TechTalk.SpecFlow.csproj" />
+    <ProjectReference Include="..\..\SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.csproj" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -26,13 +31,6 @@
     </PackageReference>
   </ItemGroup>
 
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Plugins\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj" />
-    <ProjectReference Include="..\..\Plugins\TechTalk.SpecFlow.xUnit.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.SpecFlowPlugin.csproj" />
-    <ProjectReference Include="..\..\TechTalk.SpecFlow\TechTalk.SpecFlow.csproj" />
-    <ProjectReference Include="..\..\SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.csproj" />
-  </ItemGroup>
 
 
   <ItemGroup>
@@ -45,23 +43,26 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <!-- enable experimental support for net.sdk projects via feature flag -->
-    <SpecFlow_EnableDefaultCompileItems>true</SpecFlow_EnableDefaultCompileItems>
+    <_SpecFlow_PluginTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.0</_SpecFlow_PluginTFM>
+    <_SpecFlow_PluginTFM Condition=" '$(MSBuildRuntimeType)' != 'Core'">net471</_SpecFlow_PluginTFM>
   </PropertyGroup>
 
-  <ItemGroup>
-    <SpecFlowGeneratorPlugins Include="../../Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/bin/$(Configuration)/$(SpecFlow_Core_Generator_TFM)/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Features\" />
-  </ItemGroup>
 
   <Target Name="PreBuild">
     <MSBuild Projects="..\..\SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.csproj" ContinueOnError="false" Properties="TargetFramework=$(SpecFlow_Core_Tools_TFM)"/>
     <MSBuild Projects="..\..\Plugins\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj" ContinueOnError="false" Properties="TargetFramework=$(SpecFlow_Core_Generator_TFM)"/>
-
   </Target>
+
+  <ItemGroup>
+    <SpecFlowGeneratorPlugins Include="../../Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/bin/$(Configuration)/$(SpecFlow_Core_Generator_TFM)/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.dll" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <_SpecFlow_TaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' And '$(_SpecFlow_TaskFolder)' == ''">netcoreapp2.0</_SpecFlow_TaskFolder>
+    <_SpecFlow_TaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' And '$(_SpecFlow_TaskFolder)' == ''">net471</_SpecFlow_TaskFolder>
+    <_SpecFlow_TaskAssembly>..\..\SpecFlow.Tools.MsBuild.Generation\bin\$(Configuration)\$(_SpecFlow_TaskFolder)\SpecFlow.Tools.MsBuild.Generation.dll</_SpecFlow_TaskAssembly>
+  </PropertyGroup>
+
 
   <!-- simulate nuget imports here-->
   <Import Project="..\..\SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.targets" />

--- a/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
@@ -90,6 +90,7 @@
   <Target Name="PreBuild">
     <MSBuild Projects="..\..\SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.csproj" ContinueOnError="false" Properties="TargetFramework=$(SpecFlow_Core_Tools_TFM)"/>
     <MSBuild Projects="..\TechTalk.SpecFlow.Specs.Generator.SpecFlowPlugin\TechTalk.SpecFlow.Specs.Generator.SpecFlowPlugin.csproj" ContinueOnError="false" Properties="TargetFramework=$(SpecFlow_Core_Tools_TFM)"/>
+    <MSBuild Projects="..\..\Plugins\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin\TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin.csproj" ContinueOnError="false" Properties="TargetFramework=$(SpecFlow_Core_Generator_TFM)"/>
   </Target>
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Fixes:
 + specflow.json is copied to output directory automatically https://github.com/techtalk/SpecFlow/issues/1315
 + A scenario with an "Examples" block should be treated as a Scenario Outline according to Gherkin v6
 + step definition method with "object" parameter type might not match
++ AssemblyHooks are now marked as [GeneratedCode] so that Code Analyzers don't check them.
 
 
 Changes:


### PR DESCRIPTION
In order to prevent codeanalysis tools to generate warnings for AssemblyHooks, the [GeneratedCode] attribute was added.

Fixes #1789 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added an entry to the changelog
