### PR TITLE
Allow override of Set Test Method Categories to allow NUnit Retry plugin to be developed

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
@@ -104,7 +104,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(testMethod, DESCRIPTION_ATTR, friendlyTestName);
         }
 
-        public void SetTestMethodCategories(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> scenarioCategories)
+        public virtual void SetTestMethodCategories(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> scenarioCategories)
         {
             CodeDomHelper.AddAttributeForEachValue(testMethod, CATEGORY_ATTR, scenarioCategories);
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Changes:
     + SpecFlow.xUnit has a dependency on Xunit.SkippableFact
 + Added support for TypeConverter attributes.
 + All Steps.Given, Steps.When, Steps.Then, Steps.But and Steps.And methods are obsolete; these methods will be removed in SpecFlow 3.2. For more details refer to https://github.com/techtalk/SpecFlow/issues/1733
++ Now allows override of method categories in NUnit to allow for plugin development on this function
 
 3.0 - 2019-06-27
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Changes SetTestMethodCategories so that this method can be overridden by plugins. This is needed for NUnit Retry since they have to happen at the method level, not the class level.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
