### PR TITLE
Use Path.Combine to build GeneratedSpecFlowAssemblyHooksFile path

### DIFF
--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/SpecFlow.MsTest.targets
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/SpecFlow.MsTest.targets
@@ -27,7 +27,7 @@
 
     <SourceSpecFlowAssemblyHooksFile Condition="'$(SourceSpecFlowAssemblyHooksFile)' == ''">$(MSBuildThisFileDirectory)MSTest.AssemblyHooks$(DefaultLanguageSourceExtension)</SourceSpecFlowAssemblyHooksFile>
     <GenerateSpecFlowAssemblyHooksFile Condition="'$(GenerateSpecFlowAssemblyHooksFile)' == ''">true</GenerateSpecFlowAssemblyHooksFile>
-    <GeneratedSpecFlowAssemblyHooksFile>$(ProjectDir)$([MSBuild]::Unescape('$(IntermediateOutputPath)'))MSTest.AssemblyHooks$(DefaultLanguageSourceExtension)</GeneratedSpecFlowAssemblyHooksFile>
+    <GeneratedSpecFlowAssemblyHooksFile>$([System.IO.Path]::Combine($(ProjectDir),$([MSBuild]::Unescape('$(IntermediateOutputPath)'))))MSTest.AssemblyHooks$(DefaultLanguageSourceExtension)</GeneratedSpecFlowAssemblyHooksFile>
     <_SpecFlow_EffectiveRootNamespace Condition="'$(RootNamespace)' != ''">$(RootNamespace)</_SpecFlow_EffectiveRootNamespace>
     <_SpecFlow_EffectiveRootNamespace Condition="'$(RootNamespace)' == ''">SpecFlow.GeneratedTests</_SpecFlow_EffectiveRootNamespace>
   </PropertyGroup>

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/SpecFlow.NUnit.targets
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/SpecFlow.NUnit.targets
@@ -27,7 +27,7 @@
 
     <SourceSpecFlowAssemblyHooksFile Condition="'$(SourceSpecFlowAssemblyHooksFile)' == ''">$(MSBuildThisFileDirectory)NUnit.AssemblyHooks$(DefaultLanguageSourceExtension)</SourceSpecFlowAssemblyHooksFile>
     <GenerateSpecFlowAssemblyHooksFile Condition="'$(GenerateSpecFlowAssemblyHooksFile)' == ''">true</GenerateSpecFlowAssemblyHooksFile>
-    <GeneratedSpecFlowAssemblyHooksFile>$(ProjectDir)$([MSBuild]::Unescape('$(IntermediateOutputPath)'))NUnit.AssemblyHooks$(DefaultLanguageSourceExtension)</GeneratedSpecFlowAssemblyHooksFile>
+    <GeneratedSpecFlowAssemblyHooksFile>$([System.IO.Path]::Combine($(ProjectDir),$([MSBuild]::Unescape('$(IntermediateOutputPath)'))))NUnit.AssemblyHooks$(DefaultLanguageSourceExtension)</GeneratedSpecFlowAssemblyHooksFile>
     <_SpecFlow_EffectiveRootNamespace Condition="'$(RootNamespace)' != ''">$(RootNamespace)</_SpecFlow_EffectiveRootNamespace>
     <_SpecFlow_EffectiveRootNamespace Condition="'$(RootNamespace)' == ''">SpecFlow.GeneratedTests</_SpecFlow_EffectiveRootNamespace>
   </PropertyGroup>

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/SpecFlow.xUnit.targets
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/SpecFlow.xUnit.targets
@@ -26,7 +26,7 @@
 
     <SourceSpecFlowAssemblyHooksFile Condition="'$(SourceSpecFlowAssemblyHooksFile)' == ''">$(MSBuildThisFileDirectory)xUnit.AssemblyHooks$(DefaultLanguageSourceExtension)</SourceSpecFlowAssemblyHooksFile>
     <GenerateSpecFlowAssemblyHooksFile Condition="'$(GenerateSpecFlowAssemblyHooksFile)' == ''">true</GenerateSpecFlowAssemblyHooksFile>
-    <GeneratedSpecFlowAssemblyHooksFile>$(ProjectDir)$([MSBuild]::Unescape('$(IntermediateOutputPath)'))xUnit.AssemblyHooks$(DefaultLanguageSourceExtension)</GeneratedSpecFlowAssemblyHooksFile>
+    <GeneratedSpecFlowAssemblyHooksFile>$([System.IO.Path]::Combine($(ProjectDir),$([MSBuild]::Unescape('$(IntermediateOutputPath)'))))xUnit.AssemblyHooks$(DefaultLanguageSourceExtension)</GeneratedSpecFlowAssemblyHooksFile>
     <_SpecFlow_EffectiveRootNamespace Condition="'$(RootNamespace)' != ''">$(RootNamespace)</_SpecFlow_EffectiveRootNamespace>
     <_SpecFlow_EffectiveRootNamespace Condition="'$(RootNamespace)' == ''">SpecFlow.GeneratedTests</_SpecFlow_EffectiveRootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
When IntermediateOutputPath is an absolute path simple concatenation results in a non functional path, but by using Path.Combine which takes absolute paths into consideration there is no problem.

Fixes #1892

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
