### PR TITLE
Added AfterLastStep hook

### DIFF
--- a/TechTalk.SpecFlow/Bindings/Discovery/SpecFlowAttributesFilter.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/SpecFlowAttributesFilter.cs
@@ -27,7 +27,8 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
             typeof(BeforeScenarioBlockAttribute),
             typeof(AfterScenarioBlockAttribute),
             typeof(BeforeAttribute),
-            typeof(AfterAttribute)
+            typeof(AfterAttribute),
+            typeof(AfterLastStepAttribute)
         };
 
         public IEnumerable<Attribute> FilterForSpecFlowAttributes(IEnumerable<Attribute> customAttributes)

--- a/TechTalk.SpecFlow/Bindings/HookType.cs
+++ b/TechTalk.SpecFlow/Bindings/HookType.cs
@@ -11,6 +11,7 @@ namespace TechTalk.SpecFlow.Bindings
         BeforeScenarioBlock,
         AfterScenarioBlock,
         BeforeStep,
-        AfterStep
+        AfterStep,
+        AfterLastStep
     }
 }

--- a/TechTalk.SpecFlow/HookAttributes.cs
+++ b/TechTalk.SpecFlow/HookAttributes.cs
@@ -101,4 +101,14 @@ namespace TechTalk.SpecFlow
     {
         public AfterStepAttribute(params string[] tags) : base(HookType.AfterStep, tags) { }
     }
+
+    /// <summary>
+    /// Specifies a hook that will be executed after last step in scenario but before AfterScenarioAttribute <see cref="AfterScenarioAttribute"/>
+    /// This may be useful in some cases due to the fact that when AfterScenarioAttribute will be called, scenario execution state is considered completed.
+    /// As for this hook scenario state won't yet be completed but all steps will be already executed.
+    /// </summary>
+    public class AfterLastStepAttribute : HookAttribute
+    {
+        public AfterLastStepAttribute(params string[] tags) : base(HookType.AfterLastStep, tags) { }
+    }
 }

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -48,7 +48,7 @@ namespace TechTalk.SpecFlow.Infrastructure
         private bool _testRunnerEndExecuted = false;
         private object _testRunnerEndExecutedLock = new object();
         private bool _testRunnerStartExecuted = false;
-        
+
 
         public TestExecutionEngine(
             IStepFormatter stepFormatter,
@@ -67,9 +67,9 @@ namespace TechTalk.SpecFlow.Infrastructure
             ITestResultFactory testResultFactory,
             ITestPendingMessageFactory testPendingMessageFactory,
             ITestUndefinedMessageFactory testUndefinedMessageFactory,
-            ITestRunResultCollector testRunResultCollector, 
-            IAnalyticsEventProvider analyticsEventProvider, 
-            IAnalyticsTransmitter analyticsTransmitter, 
+            ITestRunResultCollector testRunResultCollector,
+            IAnalyticsEventProvider analyticsEventProvider,
+            IAnalyticsTransmitter analyticsTransmitter,
             ITestRunnerManager testRunnerManager,
             ITestObjectResolver testObjectResolver = null,
             IObjectContainer testThreadContainer = null) //TODO: find a better way to access the container
@@ -208,6 +208,9 @@ namespace TechTalk.SpecFlow.Infrastructure
                 var duration = _contextManager.ScenarioContext.Stopwatch.Elapsed;
                 _testTracer.TraceDuration(duration, "Scenario: " + _contextManager.ScenarioContext.ScenarioInfo.Title);
             }
+
+            //hook is intentionally called here in order to not affect scenario execution time.
+            FireScenarioEvents(HookType.AfterLastStep);
 
             var testResultResult = _testResultFactory.BuildFromContext(_contextManager.ScenarioContext, _contextManager.FeatureContext);
             switch (testResultResult)
@@ -526,7 +529,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             {
                 throw new ArgumentNullException(nameof(_contextManager));
             }
-            
+
             if (_contextManager.ScenarioContext == null)
             {
                 throw new ArgumentNullException(nameof(_contextManager.ScenarioContext));


### PR DESCRIPTION
<!--- Describe your changes in detail -->
"AfterLastStep" hook added. This hook will add ability of executing custom code after last step being executed, but before tests results are collected by TestExecutionEngine. This should serve purpose of updating test execution result based on non functional criteria like test execution time, custom tags, etc.

This PR is related to issue [https://github.com/SpecFlowOSS/SpecFlow/issues/1813](https://github.com/SpecFlowOSS/SpecFlow/issues/1813)

Please let me know whether this code could potentially be accepted, so I can update this PR with tests and accordingly updated documentation.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
