### PR TITLE
Fix Unix analytics

### DIFF
--- a/TechTalk.SpecFlow/Analytics/UserId/FileUserIdStore.cs
+++ b/TechTalk.SpecFlow/Analytics/UserId/FileUserIdStore.cs
@@ -5,7 +5,9 @@ namespace TechTalk.SpecFlow.Analytics.UserId
 {
     public class FileUserIdStore : IUserUniqueIdStore
     {
-        public static readonly string UserIdFilePath = Environment.ExpandEnvironmentVariables(@"%APPDATA%\SpecFlow\userid");
+        private static readonly string appDataFolder = Environment.GetFolderPath(
+                                                                    Environment.SpecialFolder.ApplicationData);
+        public static readonly string UserIdFilePath = Path.Combine(appDataFolder, "SpecFlow", "userid");
 
         private readonly Lazy<string> _lazyUniqueUserId;
         private readonly IFileService _fileService;


### PR DESCRIPTION
Use the built in `Environment.SpecialFolder.ApplicationData` to get the environment specific (Windows/Linux/Mac) `AppData` folder.
