### PR TITLE
Allow the use of custom subclasses of StepDefinitionBaseAttribute.

### DIFF
--- a/TechTalk.SpecFlow/Attributes.cs
+++ b/TechTalk.SpecFlow/Attributes.cs
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public abstract class StepDefinitionBaseAttribute : Attribute
     {
-        internal StepDefinitionType[] Types { get; private set; }
+        public StepDefinitionType[] Types { get; private set; }
         public string Regex { get; set; }
 
         /// <summary>

--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
@@ -74,11 +74,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
         private bool IsStepDefinitionAttribute(BindingSourceAttribute attribute)
         {
-            return
-                typeof(GivenAttribute).IsAssignableFrom(attribute.AttributeType) ||
-                typeof(WhenAttribute).IsAssignableFrom(attribute.AttributeType) ||
-                typeof(ThenAttribute).IsAssignableFrom(attribute.AttributeType) ||
-                typeof(StepDefinitionAttribute).IsAssignableFrom(attribute.AttributeType);
+            return typeof(StepDefinitionBaseAttribute).IsAssignableFrom(attribute.AttributeType);
         }
 
         private bool IsHookAttribute(BindingSourceAttribute attribute)
@@ -301,16 +297,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
         private IEnumerable<StepDefinitionType> GetStepDefinitionTypes(BindingSourceAttribute stepDefinitionAttribute)
         {
-            if (typeof(GivenAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
-                return new[] { StepDefinitionType.Given };
-            if (typeof(WhenAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
-                return new[] { StepDefinitionType.When };
-            if (typeof(ThenAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
-                return new[] { StepDefinitionType.Then };
-            if (typeof(StepDefinitionAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
-                return new[] { StepDefinitionType.Given, StepDefinitionType.When, StepDefinitionType.Then };
-
-            return new StepDefinitionType[0];
+            return stepDefinitionAttribute.NamedAttributeValues["Types"].GetValue<IEnumerable<StepDefinitionType>>();
         }
 
         private void ApplyForScope(BindingScope[] scopes, Action<BindingScope> action)

--- a/TechTalk.SpecFlow/Bindings/Discovery/SpecFlowAttributesFilter.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/SpecFlowAttributesFilter.cs
@@ -10,11 +10,8 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         private readonly IReadOnlyCollection<Type> _validAttributeTypes = new[]
         {
             typeof(BindingAttribute),
-            typeof(GivenAttribute),
-            typeof(WhenAttribute),
-            typeof(ThenAttribute),
             typeof(HookAttribute),
-            typeof(StepDefinitionAttribute),
+            typeof(StepDefinitionBaseAttribute),
             typeof(StepArgumentTransformationAttribute),
             typeof(TableAliasesAttribute),
             typeof(ScopeAttribute),

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -191,6 +191,23 @@ namespace TechTalk.SpecFlow.RuntimeTests
             }
         }
 
+        [Binding]
+        public class BindingClassWithCustomStepDefinitionAttribute
+        {
+            public class GivenAndWhenAttribute : StepDefinitionBaseAttribute
+            {
+                public GivenAndWhenAttribute(string regex)
+                    : base(regex, new[] { StepDefinitionType.Given, StepDefinitionType.When } )
+                {
+                }
+            }
+
+            [GivenAndWhen("given and when")]
+            public void GivenAndWhen()
+            {
+            }
+        }
+
         [Fact]
         public void ShouldFindBinding_WithDefaultOrder()
         {
@@ -360,6 +377,19 @@ namespace TechTalk.SpecFlow.RuntimeTests
             Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Given));
             Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.When));
             Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Then));
+        }
+
+        [Fact]
+        public void ShouldFindStepDefinitionsWithCustomAttribute()
+        {
+            var builder = new RuntimeBindingRegistryBuilder(bindingSourceProcessorStub, new SpecFlowAttributesFilter());
+
+            builder.BuildBindingsFromType(typeof(BindingClassWithCustomStepDefinitionAttribute));
+
+            Assert.Equal(2, bindingSourceProcessorStub.StepDefinitionBindings.Count);
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Given));
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.When));
+            Assert.Equal(0, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Then));
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,14 @@
 Changes since 3.1.97
 
+Features:
++ Allow the use of custom subclasses of StepDefinitionBaseAttribute.
+
 Fixes for Development:
 + Changed unit tests to ignore custom user overrides to data formatting in en-US locale
 
 API Changes:
 + Now allows override of method categories in NUnit to allow for plugin development on this function
+
 
 Changes since 3.1.89
 


### PR DESCRIPTION
These changes allow for creation and usage of custom stepdefinition attributes like:
```
public class GivenAndWhenAttribute : StepDefinitionBaseAttribute
{
    public GivenAndWhenAttribute(string regex)
        : base(regex, new[] { StepDefinitionType.Given, StepDefinitionType.When })
    {
    }
}
```
Closes #1932 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
