### PR TITLE
Fix flaky test EnqueueMessage_nTimes_ShouldBeSynchronous

### DIFF
--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TraceListenerQueueTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TraceListenerQueueTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +12,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 {
     public class TraceListenerQueueTests
     {
-        [Theory(DisplayName ="EnqueueMessage n times should yield messages synchronously", Skip = "flacky test")]
+        [Theory(DisplayName ="EnqueueMessage n times should yield messages synchronously")]
         [InlineData(2)]
         [InlineData(32)]
         [InlineData(128)]
@@ -20,7 +21,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
             // ARRANGE
             var countdown = new CountdownEvent(times);
             var semaphore = new SemaphoreSlim(1, 1);
-            var testOutputList = new List<string>();
+            var testOutputList = new ConcurrentBag<string>();
 
             bool failureOnSemaphoreEntering = false;
 


### PR DESCRIPTION
List<T> is not threadsafe and replaced with ConcurrentBag<T>

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Only improved a test case
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory) 
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

fixes https://github.com/SpecFlowOSS/SpecFlow/issues/1771 

I'm not sure what is mandatory for this change. I don't think it should be in the changelog