### PR TITLE
Fix parallel executions exceptions

### DIFF
--- a/TechTalk.SpecFlow/BindingSkeletons/FileBasedSkeletonTemplateProvider.cs
+++ b/TechTalk.SpecFlow/BindingSkeletons/FileBasedSkeletonTemplateProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace TechTalk.SpecFlow.BindingSkeletons
 {
@@ -10,12 +11,9 @@ namespace TechTalk.SpecFlow.BindingSkeletons
         private const string templateSeparator = ">>>";
         private Dictionary<string, string> templates = null;
 
-        private void EnsureInitialized()
+        private Dictionary<string, string> GetTemplates()
         {
-            if (templates != null)
-                return;
-
-            templates = new Dictionary<string, string>();
+            var templates = new Dictionary<string, string>();
 
             string templateFileContent = GetTemplateFileContent();
             var templateItems = templateFileContent.Split(new[] {templateSeparator}, StringSplitOptions.RemoveEmptyEntries);
@@ -28,6 +26,8 @@ namespace TechTalk.SpecFlow.BindingSkeletons
                     throw new SpecFlowException(string.Format("Invalid sftemplate file! Duplicate key: '{0}'.", templateItem.Key));
                 templates.Add(templateItem.Key, templateItem.Body);
             }
+
+            return templates;
         }
 
         protected abstract string GetTemplateFileContent();
@@ -38,7 +38,7 @@ namespace TechTalk.SpecFlow.BindingSkeletons
 
         internal protected virtual string GetTemplate(string key)
         {
-            EnsureInitialized();
+            LazyInitializer.EnsureInitialized(ref templates, GetTemplates);
 
             string template;
             if (!templates.TryGetValue(key, out template))

--- a/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
@@ -49,7 +49,7 @@ namespace TechTalk.SpecFlow.Infrastructure
 
             private void DisposeInstance()
             {
-                objectContainer.Dispose();
+                objectContainer?.Dispose();
                 instance = null;
                 objectContainer = null;
             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Features:
 
 Fixes for Development:
 + Changed unit tests to ignore custom user overrides to data formatting in en-US locale
++ Some errors could randomly happen when running tests in parallel
 
 API Changes:
 + Now allows override of method categories in NUnit to allow for plugin development on this function


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


This MR prevents these 2 multi-thread related errors that happen randomly when running tests in parallel:

```
TechTalk.SpecFlow.SpecFlowException : Invalid sftemplate file! Duplicate key: 'CSharp/StepDefinitionRegex'.
   at TechTalk.SpecFlow.BindingSkeletons.FileBasedSkeletonTemplateProvider.EnsureInitialized()
```

```
System.NullReferenceException : Object reference not set to an instance of an object.
 TearDown : System.NullReferenceException : Object reference not set to an instance of an object.
    at TechTalk.SpecFlow.Infrastructure.ContextManager.InitializeScenarioContext(ScenarioInfo scenarioInfo)
```
