### PR TITLE
Recognize dates when generating steps

### DIFF
--- a/TechTalk.SpecFlow/BindingSkeletons/StepTextAnalyzer.cs
+++ b/TechTalk.SpecFlow/BindingSkeletons/StepTextAnalyzer.cs
@@ -1,8 +1,8 @@
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using TechTalk.SpecFlow.Bindings;
 
 namespace TechTalk.SpecFlow.BindingSkeletons
 {
@@ -38,13 +38,17 @@ namespace TechTalk.SpecFlow.BindingSkeletons
         {
             var result = new AnalyzedStepText();
 
-            var paramMatches = RecognizeQuotedTexts(stepText).Concat(RecognizeIntegers(stepText)).Concat(RecognizeDecimals(stepText, bindingCulture))
-                .OrderBy(m => m.Index).ThenByDescending(m => m.Length);
+            var paramMatches = RecognizeQuotedTexts(stepText)
+                               .Concat(RecognizeDates(stepText))
+                               .Concat(RecognizeIntegers(stepText))
+                               .Concat(RecognizeDecimals(stepText, bindingCulture))
+                               .OrderBy(m => m.Capture.Index)
+                               .ThenByDescending(m => m.Capture.Length);
 
             int textIndex = 0;
             foreach (var paramMatch in paramMatches)
             {
-                if (paramMatch.Index < textIndex)
+                if (paramMatch.Capture.Index < textIndex)
                     continue;
 
                 const string singleQuoteRegexPattern = "[^']*";
@@ -52,8 +56,8 @@ namespace TechTalk.SpecFlow.BindingSkeletons
                 const string defaultRegexPattern = ".*";
 
                 string regexPattern = defaultRegexPattern;
-                string value = paramMatch.Value;
-                int index = paramMatch.Index;
+                string value = paramMatch.Capture.Value;
+                int index = paramMatch.Capture.Index;
 
                 switch (value.Substring(0, 1))
                 {
@@ -70,7 +74,7 @@ namespace TechTalk.SpecFlow.BindingSkeletons
                 }
 
                 result.TextParts.Add(stepText.Substring(textIndex, index - textIndex));
-                result.Parameters.Add(AnalyzeParameter(value, bindingCulture, result.Parameters.Count, regexPattern));
+                result.Parameters.Add(AnalyzeParameter(value, bindingCulture, result.Parameters.Count, regexPattern, paramMatch.ParameterType));
                 textIndex = index + value.Length;
             }
 
@@ -78,37 +82,96 @@ namespace TechTalk.SpecFlow.BindingSkeletons
             return result;
         }
 
-        private AnalyzedStepParameter AnalyzeParameter(string value, CultureInfo bindingCulture, int paramIndex, string regexPattern)
+        private AnalyzedStepParameter AnalyzeParameter(string value, CultureInfo bindingCulture, int paramIndex, string regexPattern, ParameterType parameterType)
         {
             string paramName = StepParameterNameGenerator.GenerateParameterName(value, paramIndex, usedParameterNames);
 
             int intParamValue;
-            if (int.TryParse(value, NumberStyles.Integer, bindingCulture, out intParamValue))
+            if (parameterType == ParameterType.Int && int.TryParse(value, NumberStyles.Integer, bindingCulture, out intParamValue))
                 return new AnalyzedStepParameter("Int32", paramName, regexPattern);
 
             decimal decimalParamValue;
-            if (decimal.TryParse(value, NumberStyles.Number, bindingCulture, out decimalParamValue))
+            if (parameterType == ParameterType.Decimal && decimal.TryParse(value, NumberStyles.Number, bindingCulture, out decimalParamValue))
                 return new AnalyzedStepParameter("Decimal", paramName, regexPattern);
+
+            DateTime dateParamValue;
+            if (parameterType == ParameterType.Date && DateTime.TryParse(value, bindingCulture, DateTimeStyles.AllowWhiteSpaces, out dateParamValue))
+                return new AnalyzedStepParameter("DateTime", paramName, regexPattern);
 
             return new AnalyzedStepParameter("String", paramName, regexPattern);
         }
 
         private static readonly Regex quotesRe = new Regex(@"""+(?<param>.*?)""+|'+(?<param>.*?)'+|(?<param>\<.*?\>)");
-        private IEnumerable<Capture> RecognizeQuotedTexts(string stepText)
+        private IEnumerable<CaptureWithContext> RecognizeQuotedTexts(string stepText)
         {
-            return quotesRe.Matches(stepText).Cast<Match>().Select(m => (Capture)m.Groups["param"]);
+            return quotesRe.Matches(stepText)
+                           .Cast<Match>()
+                           .Select(m => (Capture)m.Groups["param"])
+                           .Select(c => new CaptureWithContext(c, ParameterType.Text));
         }
 
         private static readonly Regex intRe = new Regex(@"-?\d+");
-        private IEnumerable<Capture> RecognizeIntegers(string stepText)
+
+        private IEnumerable<CaptureWithContext> RecognizeIntegers(string stepText)
         {
-            return intRe.Matches(stepText).Cast<Capture>();
+            return intRe.Matches(stepText)
+                        .Cast<Capture>()
+                        .Select(c => new CaptureWithContext(c, ParameterType.Int));
         }
 
-        private IEnumerable<Capture> RecognizeDecimals(string stepText, CultureInfo bindingCulture)
+        private IEnumerable<CaptureWithContext> RecognizeDecimals(string stepText, CultureInfo bindingCulture)
         {
             Regex decimalRe = new Regex(string.Format(@"-?\d+{0}\d+", bindingCulture.NumberFormat.NumberDecimalSeparator));
-            return decimalRe.Matches(stepText).Cast<Capture>();
+            return decimalRe.Matches(stepText)
+                            .Cast<Capture>()
+                            .Select(c => new CaptureWithContext(c, ParameterType.Decimal));
+        }
+
+        private static readonly Regex dateRe = new Regex(string.Join("|", GetDateFormats()));
+
+        /// <summary>
+        /// note: space separator not supported to prevent clashes
+        /// </summary>
+        private static IEnumerable<string> GetDateFormats()
+        {
+            yield return GetDateFormat("/");
+            yield return GetDateFormat("-");
+            yield return GetDateFormat(".");
+        }
+
+        private static string GetDateFormat(string separator)
+        {
+            var separatorEscaped = Regex.Escape(separator);
+            return @"\d{1,4}" + separatorEscaped + @"\d{1,4}" + separatorEscaped + @"\d{1,4}";
+        }
+
+        private IEnumerable<CaptureWithContext> RecognizeDates(string stepText)
+        {
+            return dateRe.Matches(stepText)
+                         .Cast<Capture>()
+                         .Select(c => new CaptureWithContext(c, ParameterType.Date));
+        }
+
+        private class CaptureWithContext
+        {
+
+            public Capture Capture { get; }
+
+            public ParameterType ParameterType { get; }
+
+            public CaptureWithContext(Capture capture, ParameterType parameterType)
+            {
+                Capture = capture;
+                ParameterType = parameterType;
+            }
+        }
+
+        private enum ParameterType
+        {
+            Text,
+            Int,
+            Decimal,
+            Date
         }
     }
 }

--- a/TechTalk.SpecFlow/BindingSkeletons/StepTextAnalyzer.cs
+++ b/TechTalk.SpecFlow/BindingSkeletons/StepTextAnalyzer.cs
@@ -107,24 +107,20 @@ namespace TechTalk.SpecFlow.BindingSkeletons
             return quotesRe.Matches(stepText)
                            .Cast<Match>()
                            .Select(m => (Capture)m.Groups["param"])
-                           .Select(c => new CaptureWithContext(c, ParameterType.Text));
+                           .ToCaptureWithContext(ParameterType.Text);
         }
 
         private static readonly Regex intRe = new Regex(@"-?\d+");
 
         private IEnumerable<CaptureWithContext> RecognizeIntegers(string stepText)
         {
-            return intRe.Matches(stepText)
-                        .Cast<Capture>()
-                        .Select(c => new CaptureWithContext(c, ParameterType.Int));
+            return intRe.Matches(stepText).ToCaptureWithContext(ParameterType.Int);
         }
 
         private IEnumerable<CaptureWithContext> RecognizeDecimals(string stepText, CultureInfo bindingCulture)
         {
             Regex decimalRe = new Regex(string.Format(@"-?\d+{0}\d+", bindingCulture.NumberFormat.NumberDecimalSeparator));
-            return decimalRe.Matches(stepText)
-                            .Cast<Capture>()
-                            .Select(c => new CaptureWithContext(c, ParameterType.Decimal));
+            return decimalRe.Matches(stepText).ToCaptureWithContext(ParameterType.Decimal);
         }
 
         private static readonly Regex dateRe = new Regex(string.Join("|", GetDateFormats()));
@@ -147,31 +143,40 @@ namespace TechTalk.SpecFlow.BindingSkeletons
 
         private IEnumerable<CaptureWithContext> RecognizeDates(string stepText)
         {
-            return dateRe.Matches(stepText)
-                         .Cast<Capture>()
-                         .Select(c => new CaptureWithContext(c, ParameterType.Date));
+            return dateRe.Matches(stepText).ToCaptureWithContext(ParameterType.Date);
         }
+    }
 
-        private class CaptureWithContext
+    internal static class MatchCollectionExtensions
+    {
+        public static IEnumerable<CaptureWithContext> ToCaptureWithContext(this MatchCollection collection, ParameterType parameterType)
         {
-
-            public Capture Capture { get; }
-
-            public ParameterType ParameterType { get; }
-
-            public CaptureWithContext(Capture capture, ParameterType parameterType)
-            {
-                Capture = capture;
-                ParameterType = parameterType;
-            }
+            return collection.Cast<Capture>().ToCaptureWithContext(parameterType);
         }
-
-        private enum ParameterType
+        public static IEnumerable<CaptureWithContext> ToCaptureWithContext(this IEnumerable<Capture> collection, ParameterType parameterType)
         {
-            Text,
-            Int,
-            Decimal,
-            Date
+            return collection.Select(c => new CaptureWithContext(c, parameterType));
         }
+    }
+
+    internal class CaptureWithContext
+    {
+        public Capture Capture { get; }
+
+        public ParameterType ParameterType { get; }
+
+        public CaptureWithContext(Capture capture, ParameterType parameterType)
+        {
+            Capture = capture;
+            ParameterType = parameterType;
+        }
+    }
+
+    internal enum ParameterType
+    {
+        Text,
+        Int,
+        Decimal,
+        Date
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
@@ -9,7 +9,7 @@ using FluentAssertions;
 
 namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 {
-    
+
     public class StepTextAnalyzerTests
     {
         private readonly CultureInfo bindingCulture = new CultureInfo("en-US");
@@ -101,6 +101,26 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
             result.TextParts[0].Should().Be("I have ");
             result.TextParts[1].Should().Be(" bars");
             result.Parameters[0].Type.Should().Be("Int32");
+        }
+
+        [Theory]
+        [InlineData("2030-12-23", "en-US")]
+        [InlineData("2030/12/23", "en-US")]
+        [InlineData("23-12-2030", "nl-NL")]
+        [InlineData("23.12.2030", "nl-BE")]
+        public void Should_recognize_dates(string dateString, string cultureCode)
+        {
+            var sut = new StepTextAnalyzer();
+
+            var culture = CultureInfo.GetCultureInfo(cultureCode);
+
+            var result = sut.Analyze("Zombie apocalypse is expected at " + dateString, culture);
+            result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
+            result.TextParts.Count.Should().Be(2);
+            result.TextParts[0].Should().Be("Zombie apocalypse is expected at ");
+            result.TextParts[1].Should().Be("");
+            result.Parameters[0].Type.Should().Be("DateTime");
         }
 
         [Fact]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
@@ -117,10 +117,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
             var result = sut.Analyze("Zombie apocalypse is expected at " + dateString, culture);
             result.Parameters.Count.Should().Be(1);
             result.Parameters[0].Name.Should().Be("p0");
+            result.Parameters[0].Type.Should().Be("DateTime");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("Zombie apocalypse is expected at ");
             result.TextParts[1].Should().Be("");
-            result.Parameters[0].Type.Should().Be("DateTime");
         }
 
         [Fact]

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,8 +5,6 @@ Fixes:
 + Save generated files with UTF8-BOM encoding.
 + Revert "Replace NUnit.Framework.DescriptionAttribute to TestName in NUnit generator #1225" because of problems with the NUnit Test Adapter
 
-Features:
-+ Recognize dates when generating steps - no datetimes yet
 
 Changes since 3.1.86
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,9 @@ Fixes:
 + Save generated files with UTF8-BOM encoding.
 + Revert "Replace NUnit.Framework.DescriptionAttribute to TestName in NUnit generator #1225" because of problems with the NUnit Test Adapter
 
+Features:
++ Recognize dates when generating steps - no datetimes yet
+
 Changes since 3.1.86
 
 Fixes:


### PR DESCRIPTION
Recognize dates when generating steps. Datetimes aren't supported *yet*

Supported formats:

The ones that will be successfully parsed by Datetime.TryParse and limited to the following separators: `/`, `-` and `.`

Examples:

- 2030-12-23
- 2030/12/23
- 23-12-2030
- 23.12.2030



### Guidance needed
Please give me a glue if I could some more tests on a higher level.  I'm not sure if I have covered all needed parts and how I could test the end result easily.


### notes to reviewer

Added `CaptureWithContext` / `ParameterType` as there where clashes:

- `23.12.2030` was successfully parsed with `decimal.TryParse` (unwanted)
- `4.2`  was successfully parsed with `DateTime.TryParse` (unwanted)



<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [X] I've added tests for my code. (most of the time mandatory)
- [X] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation. **not sure**
- [ ] I have updated the documentation accordingly.
