### PR TITLE
Scenario info arguments

### DIFF
--- a/TechTalk.SpecFlow.Generator/Generation/GeneratorConstants.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/GeneratorConstants.cs
@@ -15,5 +15,7 @@
         public const string TESTRUNNER_FIELD = "testRunner";
         public const string SPECFLOW_NAMESPACE = "TechTalk.SpecFlow";
         public const string SCENARIO_OUTLINE_EXAMPLE_TAGS_PARAMETER = "exampleTags";
+        public const string SCENARIO_TAGS_VARIABLE_NAME = "tagsOfScenario";
+        public const string SCENARIO_ARGUMENTS_VARIABLE_NAME = "argumentsOfScenario";
     }
 }

--- a/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using Gherkin.Ast;
 using TechTalk.SpecFlow.Configuration;
@@ -159,12 +160,15 @@ namespace TechTalk.SpecFlow.Generator.Generation
 
             AddVariableForTags(testMethod, tagsExpression);
 
+            AddVariableForArguments(testMethod, paramToIdentifier);
+
             testMethod.Statements.Add(
                 new CodeVariableDeclarationStatement(typeof(ScenarioInfo), "scenarioInfo",
                     new CodeObjectCreateExpression(typeof(ScenarioInfo),
                         new CodePrimitiveExpression(scenario.Name),
                         new CodePrimitiveExpression(scenario.Description),
-                        tagsExpression)));
+                        new CodeVariableReferenceExpression(GeneratorConstants.SCENARIO_TAGS_VARIABLE_NAME),
+                        new CodeVariableReferenceExpression(GeneratorConstants.SCENARIO_ARGUMENTS_VARIABLE_NAME))));
 
             GenerateScenarioInitializeCall(generationContext, scenario, testMethod);
 
@@ -175,12 +179,36 @@ namespace TechTalk.SpecFlow.Generator.Generation
 
         private void AddVariableForTags(CodeMemberMethod testMethod, CodeExpression tagsExpression)
         {
-            var tagVariable = new CodeVariableDeclarationStatement(typeof(string[]), "tagsOfScenario", tagsExpression);
+            var tagVariable = new CodeVariableDeclarationStatement(typeof(string[]), GeneratorConstants.SCENARIO_TAGS_VARIABLE_NAME, tagsExpression);
 
             testMethod.Statements.Add(tagVariable);
         }
 
-        internal void GenerateTestMethodBody(TestClassGenerationContext generationContext, StepsContainer scenario, CodeMemberMethod testMethod, ParameterSubstitution paramToIdentifier,SpecFlowFeature feature)
+        private void AddVariableForArguments(CodeMemberMethod testMethod, ParameterSubstitution paramToIdentifier)
+        {
+            var argumentsExpression = new CodeVariableDeclarationStatement(typeof(OrderedDictionary),
+                GeneratorConstants.SCENARIO_ARGUMENTS_VARIABLE_NAME,
+                new CodeObjectCreateExpression(typeof(OrderedDictionary)));
+
+            testMethod.Statements.Add(argumentsExpression);
+
+            if (paramToIdentifier != null)
+            {
+                foreach (var parameter in paramToIdentifier)
+                {
+                    var addArgumentExpression = new CodeMethodInvokeExpression(
+                        new CodeMethodReferenceExpression(
+                            new CodeTypeReferenceExpression(new CodeTypeReference(GeneratorConstants.SCENARIO_ARGUMENTS_VARIABLE_NAME)),
+                            nameof(OrderedDictionary.Add)),
+                        new CodePrimitiveExpression(parameter.Key),
+                        new CodeVariableReferenceExpression(parameter.Value));
+
+                    testMethod.Statements.Add(addArgumentExpression);
+                }
+            }
+        }
+
+        internal void GenerateTestMethodBody(TestClassGenerationContext generationContext, StepsContainer scenario, CodeMemberMethod testMethod, ParameterSubstitution paramToIdentifier, SpecFlowFeature feature)
         {
             var statementsWhenScenarioIsIgnored = new CodeStatement[] { new CodeExpressionStatement(CreateTestRunnerSkipScenarioCall()) };
             var statementsWhenScenarioIsExecuted = new List<CodeStatement>
@@ -230,7 +258,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
             var ifIsNullStatement = new CodeConditionStatement(CreateCheckForNullExpression(tagsOfScenarioVariableReferenceExpression), new CodeAssignStatement(isScenarioIgnoredVariableReferenceExpression,
                 new CodeMethodInvokeExpression(tagsOfScenarioVariableReferenceExpression, ignoreLinqStatement)));
 
-            
+
             var ifIsFeatureTagsNullStatement = new CodeConditionStatement(CreateCheckForNullExpression(featureFileTagFieldReferenceExpression), new CodeAssignStatement(isFeatureIgnoredVariableReferenceExpression,
                 new CodeMethodInvokeExpression(featureFileTagFieldReferenceExpression, ignoreLinqStatement)));
 
@@ -239,8 +267,8 @@ namespace TechTalk.SpecFlow.Generator.Generation
             testMethod.Statements.Add(ifIsFeatureTagsNullStatement);
 
 
-            var isScenarioOrFeatureIgnoredExpression = new CodeBinaryOperatorExpression(isScenarioIgnoredVariableReferenceExpression, CodeBinaryOperatorType.BooleanOr, isFeatureIgnoredVariableReferenceExpression );
-            var ifIsIgnoredStatement = new CodeConditionStatement(isScenarioOrFeatureIgnoredExpression , statementsWhenScenarioIsIgnored, statementsWhenScenarioIsExecuted.ToArray());
+            var isScenarioOrFeatureIgnoredExpression = new CodeBinaryOperatorExpression(isScenarioIgnoredVariableReferenceExpression, CodeBinaryOperatorType.BooleanOr, isFeatureIgnoredVariableReferenceExpression);
+            var ifIsIgnoredStatement = new CodeConditionStatement(isScenarioOrFeatureIgnoredExpression, statementsWhenScenarioIsIgnored, statementsWhenScenarioIsExecuted.ToArray());
 
             testMethod.Statements.Add(ifIsIgnoredStatement);
         }
@@ -276,7 +304,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
                     generationContext.ScenarioCleanupMethod.Name));
         }
 
-     
+
         private CodeMethodInvokeExpression CreateTestRunnerSkipScenarioCall()
         {
             return new CodeMethodInvokeExpression(
@@ -407,7 +435,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
             string variantName)
         {
             var testMethod = CreateTestMethod(generationContext, scenarioOutline, exampleSetTags, variantName, exampleSetIdentifier);
-            
+
 
             //call test implementation with the params
             var argumentExpressions = row.Cells.Select(paramCell => new CodePrimitiveExpression(paramCell.Value)).Cast<CodeExpression>().ToList();

--- a/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
@@ -186,7 +186,8 @@ namespace TechTalk.SpecFlow.Generator.Generation
 
         private void AddVariableForArguments(CodeMemberMethod testMethod, ParameterSubstitution paramToIdentifier)
         {
-            var argumentsExpression = new CodeVariableDeclarationStatement(typeof(OrderedDictionary),
+            var argumentsExpression = new CodeVariableDeclarationStatement(
+                typeof(OrderedDictionary),
                 GeneratorConstants.SCENARIO_ARGUMENTS_VARIABLE_NAME,
                 new CodeObjectCreateExpression(typeof(OrderedDictionary)));
 

--- a/TechTalk.SpecFlow/ScenarioInfo.cs
+++ b/TechTalk.SpecFlow/ScenarioInfo.cs
@@ -1,18 +1,21 @@
 using System;
+using System.Collections.Specialized;
 
 namespace TechTalk.SpecFlow
 {
     public class ScenarioInfo
     {
         public string[] Tags { get; private set; }
+        public IOrderedDictionary Arguments { get; }
         public string Title { get; private set; }
         public string Description { get; private set; }
 
-        public ScenarioInfo(string title, string description, params string[] tags)
+        public ScenarioInfo(string title, string description, string[] tags, IOrderedDictionary arguments)
         {
             Title = title;
             Description = description;
             Tags = tags ?? new string[0];
+            Arguments = arguments;
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/CucumberMessages/CucumberMessageSenderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/CucumberMessages/CucumberMessageSenderTests.cs
@@ -29,9 +29,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.CucumberMessages
             var testRunResultSuccessCalculatorMock = GetTestRunResultSuccessCalculatorMock();
 
             var sinkProviderMock = new Mock<ISinkProvider>();
-            sinkProviderMock.Setup(m => m.GetMessageSinksFromConfiguration()).Returns(new List<ICucumberMessageSink>() {cucumberMessageSinkMock.Object});
+            sinkProviderMock.Setup(m => m.GetMessageSinksFromConfiguration()).Returns(new List<ICucumberMessageSink>() { cucumberMessageSinkMock.Object });
             var cucumberMessageSender = new CucumberMessageSender(cucumberMessageFactoryMock.Object, platformFactoryMock.Object, fieldValueProviderMock.Object, testRunResultSuccessCalculatorMock.Object, sinkProviderMock.Object);
-            var scenarioInfo = new ScenarioInfo("Test", "Description", "Tag1");
+            var scenarioInfo = new ScenarioInfo("Test", "Description", new string[] { "Tag1" }, null);
 
             // ACT
             cucumberMessageSender.SendTestCaseStarted(scenarioInfo);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/CucumberMessages/PickleIdStoreTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/CucumberMessages/PickleIdStoreTests.cs
@@ -16,7 +16,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.CucumberMessages
             var dictionary = new Dictionary<ScenarioInfo, Guid>();
             var pickleIdStoreDictionaryFactoryMock = GetPickleIdStoreDictionaryFactoryMock(dictionary);
             var guidToCreate = new Guid(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-            var scenarioInfo = new ScenarioInfo("Title", "Description");
+            var scenarioInfo = new ScenarioInfo("Title", "Description", null, null);
             var mock = GetPickleIdGeneratorMock(guidToCreate);
 
             var pickleIdStore = new PickleIdStore(mock.Object, pickleIdStoreDictionaryFactoryMock.Object);
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.CucumberMessages
             // ARRANGE
             var existingGuid = new Guid(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
             var guidToCreate = new Guid(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-            var scenarioInfo = new ScenarioInfo("Title", "Description");
+            var scenarioInfo = new ScenarioInfo("Title", "Description", null, null);
             var dictionary = new Dictionary<ScenarioInfo, Guid> { [scenarioInfo] = existingGuid };
             var pickleIdStoreDictionaryFactoryMock = GetPickleIdStoreDictionaryFactoryMock(dictionary);
             var mock = GetPickleIdGeneratorMock(guidToCreate);
@@ -54,7 +54,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.CucumberMessages
             // ARRANGE
             var existingGuid = new Guid(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
             var guidToCreate = new Guid(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-            var scenarioInfo = new ScenarioInfo("Title", "Description");
+            var scenarioInfo = new ScenarioInfo("Title", "Description", null, null);
             var dictionary = new Dictionary<ScenarioInfo, Guid> { [scenarioInfo] = existingGuid };
             var pickleIdStoreDictionaryFactoryMock = GetPickleIdStoreDictionaryFactoryMock(dictionary);
             var mock = GetPickleIdGeneratorMock(guidToCreate);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/CucumberMessages/TestResultFactoryTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/CucumberMessages/TestResultFactoryTests.cs
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.CucumberMessages
     {
         private ScenarioContext CreateScenarioContext(ScenarioExecutionStatus scenarioExecutionStatus)
         {
-            return new ScenarioContext(null, new ScenarioInfo("",""), null)
+            return new ScenarioContext(null, new ScenarioInfo("","", null, null), null)
             {
                 ScenarioExecutionStatus = scenarioExecutionStatus
             };

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -99,7 +99,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
 
             var culture = new CultureInfo("en-US", false);
             contextManagerStub = new Mock<IContextManager>();
-            scenarioInfo = new ScenarioInfo("scenario_title", "scenario_description");
+            scenarioInfo = new ScenarioInfo("scenario_title", "scenario_description", null, null);
             scenarioContext = new ScenarioContext(scenarioContainer, scenarioInfo, testObjectResolverMock.Object);
             scenarioContainer.RegisterInstanceAs(scenarioContext);
             contextManagerStub.Setup(cm => cm.ScenarioContext).Returns(scenarioContext);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestThreadContextTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestThreadContextTests.cs
@@ -60,7 +60,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             var testThreadContainer = containerBuilder.CreateTestThreadContainer(containerBuilder.CreateGlobalContainer(typeof(TestThreadContextTests).Assembly));
             var contextManager = CreateContextManager(testThreadContainer);
             contextManager.InitializeFeatureContext(new FeatureInfo(FeatureLanguage, "test feature", null));
-            contextManager.InitializeScenarioContext(new ScenarioInfo("test scenario", "test_description"));
+            contextManager.InitializeScenarioContext(new ScenarioInfo("test scenario", "test_description", null, null));
 
             contextManager.TestThreadContext.Should().NotBeNull();
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioContext_BindingInstancesTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioContext_BindingInstancesTest.cs
@@ -20,7 +20,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             IObjectContainer testThreadContainer;
             testRunner = TestObjectFactories.CreateTestRunner(out testThreadContainer, registerTestThreadMocks, registerGlobalMocks);
-            return new ScenarioContext(new ObjectContainer(testThreadContainer), new ScenarioInfo("sample scenario", "sample scenario description", new string[0]), testThreadContainer.Resolve<ITestObjectResolver>());
+            return new ScenarioContext(new ObjectContainer(testThreadContainer), new ScenarioInfo("sample scenario", "sample scenario description", new string[0], null), testThreadContainer.Resolve<ITestObjectResolver>());
         }
 
         [Fact]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
@@ -286,7 +286,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             contextManager.InitializeStepContext(this.CreateStepInfo("I have called initialize once"));
             //// Do not call CleanupStepContext, in order to simulate an inconsistent state
-            contextManager.InitializeScenarioContext(new ScenarioInfo("the next scenario", "description of the next scenario"));
+            contextManager.InitializeScenarioContext(new ScenarioInfo("the next scenario", "description of the next scenario", null, null));
 
             var actualCurrentTopLevelStepDefinitionType = contextManager.CurrentTopLevelStepDefinitionType;
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/StepExecutionTestsBase.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/StepExecutionTestsBase.cs
@@ -121,7 +121,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             ContextManagerStub = new ContextManager(new Mock<ITestTracer>().Object, TestThreadContainer, ContainerBuilderStub);
             ContextManagerStub.InitializeFeatureContext(new FeatureInfo(FeatureLanguage, "test feature", null));
-            ContextManagerStub.InitializeScenarioContext(new ScenarioInfo("test scenario", "test scenario description"));
+            ContextManagerStub.InitializeScenarioContext(new ScenarioInfo("test scenario", "test scenario description", null, null));
 
             StepArgumentTypeConverterStub = new Mock<IStepArgumentTypeConverter>();
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/StronglyTypedContextAcessorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/StronglyTypedContextAcessorTests.cs
@@ -265,7 +265,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
         private static ScenarioContext CreateScenarioContext()
         {
-            return new ScenarioContext(new ObjectContainer(), new ScenarioInfo("Test", "Test Description", new string[] {}), new TestObjectResolver());
+            return new ScenarioContext(new ObjectContainer(), new ScenarioInfo("Test", "Test Description", new string[] {}, null), new TestObjectResolver());
         }
 
         public class ScenarioTestClass : IScenarioTestInterface

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
@@ -93,13 +93,13 @@ namespace TechTalk.SpecFlow.RuntimeTests
             {
                 var testRunner1 = TestRunnerManager.GetTestRunner(anAssembly, 0, new RuntimeTestsContainerBuilder());
                 testRunner1.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US", false), "sds", "sss"));
-                testRunner1.OnScenarioInitialize(new ScenarioInfo("foo", "foo_desc"));
+                testRunner1.OnScenarioInitialize(new ScenarioInfo("foo", "foo_desc", null, null));
                 testRunner1.OnScenarioStart();
                 var tracer1 = testRunner1.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
 
                 var testRunner2 = TestRunnerManager.GetTestRunner(anAssembly, 1, new RuntimeTestsContainerBuilder());
                 testRunner2.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US", false), "sds", "sss"));
-                testRunner2.OnScenarioInitialize(new ScenarioInfo("foo", "foo_desc"));
+                testRunner2.OnScenarioInitialize(new ScenarioInfo("foo", "foo_desc", null, null));
                 testRunner1.OnScenarioStart();
                 var tracer2 = testRunner2.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
 

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/FeatureInfo/Description.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/FeatureInfo/Description.feature
@@ -1,69 +1,4 @@
-﻿Feature: DescriptionAccessing
-
-Scenario: Check Scenario description is not empty
-	Given the following binding class
-        """
-		using System;
-		using TechTalk.SpecFlow;
-
-		[Binding]
-		public class DescriptionTestsBinding
-		{
-			[Then(@"Check ""(.*)"" match with scenario description in context")]
-			public void ThenCheckMatchWithScenarioDescriptionInContext(string desc)
-			{
-				var testValue = ScenarioContext.Current.ScenarioInfo.Description;
-				if (testValue != desc) throw new Exception("Scenario Description is incorrectly parsed"); 						 
-			}
-		}
-        """	
-
-	And there is a feature file in the project as
-         """
-		 Feature: DescriptionFeature
-		 Test Feature Description
-
-		 Scenario: ScenarioDescriptionCheck
-		 Test Scenario Description
-		 Then Check "Test Scenario Description" match with scenario description in context
-         """
-	When I execute the tests
-	Then the execution summary should contain
-         | Succeeded |
-         | 1         |
-
-Scenario: Check Scenario description is null if empty
-	Given the following binding class
-        """
-		using System;
-		using TechTalk.SpecFlow;
-
-		[Binding]
-		public class DescriptionTestsBinding
-		{	
-			[Then(@"Check that scenario description is null in context")]
-			public void ThenCheckThatScenarioDescriptionIsNullInContext()
-			{
-				var testValue = ScenarioContext.Current.ScenarioInfo.Description;
-				if (testValue != null) throw new Exception("Scenario Description is incorrectly parsed"); 						 
-			}
-		}
-        """	
-
-	And there is a feature file in the project as
-         """
-		 Feature: DescriptionFeature
-		 Test Feature Description
-
-		 Scenario: ScenarioDescriptionCheck
-		 
-		 Then Check that scenario description is null in context
-         """
-	When I execute the tests
-	Then the execution summary should contain
-         | Succeeded |
-         | 1         |
-
+﻿Feature: Feature Description Accessing
 
 Scenario: Check Feature description is null if empty
 	Given the following binding class
@@ -144,12 +79,3 @@ Scenario: Check Feature description is not empty
 	Then the execution summary should contain
          | Succeeded |
          | 1         |
-
-
-
-
-
-
-
-
-

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/ScenarioInfo/Arguments.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/ScenarioInfo/Arguments.feature
@@ -1,0 +1,84 @@
+﻿@scenario_info_arguments
+Feature: Scenario Arguments Accessing
+
+Scenario: Scenario arguments are empty for regular scenario
+	Given the following binding class
+        """
+		using System;
+		using TechTalk.SpecFlow;
+
+		[Binding]
+		public class A
+		{
+			[Then("B")]
+			public void B()
+			{
+				if (ScenarioContext.Current.ScenarioInfo.Arguments.Count != 0) throw new Exception("Scenario arguments are not empty");
+			}
+		}
+        """	
+
+	And there is a feature file in the project as
+         """
+		 Feature: A
+
+		 Scenario: B
+		 Then B
+         """
+
+	When I execute the tests
+	Then the execution summary should contain
+         | Succeeded |
+         | 1         |
+
+Scenario: Scenario arguments for outlined scenario
+	Given the following binding class
+        """
+		using System;
+		using TechTalk.SpecFlow;
+
+		[Binding]
+		public class A
+		{
+			[When("B")]
+			public void B()
+			{
+				
+			}
+
+			[BeforeScenario("tag_a")]
+			public void BeforeTagA(ScenarioContext scenarioContext)
+			{
+				if (scenarioContext.ScenarioInfo.Arguments["column 1"].ToString() != "value 1") throw new Exception($"Actual: '{scenarioContext.ScenarioInfo.Arguments["column 1"].ToString()}'");
+				if (scenarioContext.ScenarioInfo.Arguments["column 2"].ToString() != "value 2") throw new Exception($"Actual: '{scenarioContext.ScenarioInfo.Arguments["column 2"].ToString()}'");
+			}
+
+			[BeforeScenario("tag_b")]
+			public void BeforeTagB(ScenarioContext scenarioContext)
+			{
+				if (scenarioContext.ScenarioInfo.Arguments["column 1"].ToString() != "value 11") throw new Exception($"Actual: '{scenarioContext.ScenarioInfo.Arguments["column 1"].ToString()}'");
+				if (scenarioContext.ScenarioInfo.Arguments["column 2"].ToString() != "value 22") throw new Exception($"Actual: '{scenarioContext.ScenarioInfo.Arguments["column 2"].ToString()}'");
+			}
+		}
+        """	
+
+	And there is a feature file in the project as
+         """
+		 Feature: A
+
+		 Scenario Outline: B
+		 When B
+		 @tag_a
+		 Examples:
+		 	| column 1 	| column 2 	|
+		 	| value 1 	| value 2 	|
+		 @tag_b
+		 Examples:
+		 	| column 1 	| column 2 	|
+		 	| value 11 	| value 22 	|
+         """
+
+	When I execute the tests
+	Then the execution summary should contain
+         | Succeeded |
+         | 2         |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/ScenarioInfo/Description.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/ScenarioInfo/Description.feature
@@ -1,0 +1,65 @@
+﻿Feature: Scenario Description Accessing
+
+Scenario: Check Scenario description is not empty
+	Given the following binding class
+        """
+		using System;
+		using TechTalk.SpecFlow;
+
+		[Binding]
+		public class DescriptionTestsBinding
+		{
+			[Then(@"Check ""(.*)"" match with scenario description in context")]
+			public void ThenCheckMatchWithScenarioDescriptionInContext(string desc)
+			{
+				var testValue = ScenarioContext.Current.ScenarioInfo.Description;
+				if (testValue != desc) throw new Exception("Scenario Description is incorrectly parsed"); 						 
+			}
+		}
+        """	
+
+	And there is a feature file in the project as
+         """
+		 Feature: DescriptionFeature
+		 Test Feature Description
+
+		 Scenario: ScenarioDescriptionCheck
+		 Test Scenario Description
+		 Then Check "Test Scenario Description" match with scenario description in context
+         """
+	When I execute the tests
+	Then the execution summary should contain
+         | Succeeded |
+         | 1         |
+
+Scenario: Check Scenario description is null if empty
+	Given the following binding class
+        """
+		using System;
+		using TechTalk.SpecFlow;
+
+		[Binding]
+		public class DescriptionTestsBinding
+		{	
+			[Then(@"Check that scenario description is null in context")]
+			public void ThenCheckThatScenarioDescriptionIsNullInContext()
+			{
+				var testValue = ScenarioContext.Current.ScenarioInfo.Description;
+				if (testValue != null) throw new Exception("Scenario Description is incorrectly parsed"); 						 
+			}
+		}
+        """	
+
+	And there is a feature file in the project as
+         """
+		 Feature: DescriptionFeature
+		 Test Feature Description
+
+		 Scenario: ScenarioDescriptionCheck
+		 
+		 Then Check that scenario description is null in context
+         """
+	When I execute the tests
+	Then the execution summary should contain
+         | Succeeded |
+         | 1         |

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Changes since 3.1.97
 
 Features:
 + Allow the use of custom subclasses of StepDefinitionBaseAttribute.
++ Be able to get the arguments of the current executed Scenario Outline example - https://github.com/SpecFlowOSS/SpecFlow/pull/1988
 
 Fixes for Development:
 + Changed unit tests to ignore custom user overrides to data formatting in en-US locale


### PR DESCRIPTION
This PR adds new `Arguments` property to `ScenarioInfo` class and populates it on test generation side.

Fixes: #1955 , #1890 

Changes:
- `ScenarioInfo` class has new `Arguments` property
- Added tests to verify `Arguments` property is filled in correctly
- Reuse `tagsOfScenario` variable to construct `ScenarioInfo` object with less memory allocation 