### PR TITLE
RegEx performance fix in TEHelpers

### DIFF
--- a/TechTalk.SpecFlow/Assist/TEHelpers.cs
+++ b/TechTalk.SpecFlow/Assist/TEHelpers.cs
@@ -10,6 +10,9 @@ namespace TechTalk.SpecFlow.Assist
 {
     internal static class TEHelpers
     {
+        private static readonly Regex invalidPropertyNameRegex = new Regex(InvalidPropertyNamePattern, RegexOptions.Compiled);
+        private const string InvalidPropertyNamePattern = @"[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}_]";
+
         internal static T CreateTheInstanceWithTheDefaultConstructor<T>(Table table, InstanceCreationOptions creationOptions)
         {
             var instance = (T)Activator.CreateInstance(typeof(T));
@@ -84,7 +87,7 @@ namespace TechTalk.SpecFlow.Assist
         internal static string RemoveAllCharactersThatAreNotValidInAPropertyName(string name)
         {
             //Unicode groups allowed: Lu, Ll, Lt, Lm, Lo, Nl or Nd see https://msdn.microsoft.com/en-us/library/aa664670%28v=vs.71%29.aspx
-            return new Regex(@"[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}_]").Replace(name, string.Empty);
+            return invalidPropertyNameRegex.Replace(name, string.Empty);
         }
 
         internal static string NormalizePropertyNameToMatchAgainstAColumnName(string name)

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ Changes:
 
 Fixes:
 + Empty value for nullable enum should not throw an exception
++ RegEx performance fix in TEHelpers (Table column name validation)
 
 
 Fixes:


### PR DESCRIPTION
Changed invalid property name chars RegEx from being a new
instance every call to a single static compiled RegEx

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [x] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
