### PR TITLE
Only write contents when it's changed

### DIFF
--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/SpecFlow.MsTest.targets
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/SpecFlow.MsTest.targets
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateSpecFlowAssemblyHooksFileTask" Condition="'$(GenerateSpecFlowAssemblyHooksFile)' == 'true' AND '$(_SpecFlow_Tools_MsBuild_Generation_Imported)' == 'true'">
-    <ReplaceTokenInFileTask Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'" InputFile="$(SourceSpecFlowAssemblyHooksFile)" OutputFile="$(GeneratedSpecFlowAssemblyHooksFile)" TextToReplace="PROJECT_ROOT_NAMESPACE" TextToReplaceWith="$(_SpecFlow_EffectiveRootNamespace.Replace('.', '_'))" />
+    <ReplaceTokenInFileTask Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'" InputFile="$(SourceSpecFlowAssemblyHooksFile)" OutputFile="$(GeneratedSpecFlowAssemblyHooksFile)" TextToReplace="PROJECT_ROOT_NAMESPACE" TextToReplaceWith="$(_SpecFlow_EffectiveRootNamespace.Replace('.', '_'))" WriteOnlyWhenChanged="true" />
     <ItemGroup Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'">
       <Compile Include="$(GeneratedSpecFlowAssemblyHooksFile)"/>
     </ItemGroup>

--- a/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/SpecFlow.NUnit.targets
+++ b/Plugins/TechTalk.SpecFlow.NUnit.Generator.SpecFlowPlugin/build/SpecFlow.NUnit.targets
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateSpecFlowAssemblyHooksFileTask" Condition="'$(GenerateSpecFlowAssemblyHooksFile)' == 'true' AND '$(_SpecFlow_Tools_MsBuild_Generation_Imported)' == 'true'">
-    <ReplaceTokenInFileTask Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'" InputFile="$(SourceSpecFlowAssemblyHooksFile)" OutputFile="$(GeneratedSpecFlowAssemblyHooksFile)" TextToReplace="PROJECT_ROOT_NAMESPACE" TextToReplaceWith="$(_SpecFlow_EffectiveRootNamespace.Replace('.', '_'))" />
+    <ReplaceTokenInFileTask Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'" InputFile="$(SourceSpecFlowAssemblyHooksFile)" OutputFile="$(GeneratedSpecFlowAssemblyHooksFile)" TextToReplace="PROJECT_ROOT_NAMESPACE" TextToReplaceWith="$(_SpecFlow_EffectiveRootNamespace.Replace('.', '_'))" WriteOnlyWhenChanged="true" />
     <ItemGroup Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'">
       <Compile Include="$(GeneratedSpecFlowAssemblyHooksFile)"/>
     </ItemGroup>

--- a/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/SpecFlow.xUnit.targets
+++ b/Plugins/TechTalk.SpecFlow.xUnit.Generator.SpecFlowPlugin/build/SpecFlow.xUnit.targets
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateSpecFlowAssemblyHooksFileTask" Condition="'$(GenerateSpecFlowAssemblyHooksFile)' == 'true' AND '$(_SpecFlow_Tools_MsBuild_Generation_Imported)' == 'true'">
-    <ReplaceTokenInFileTask Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'" InputFile="$(SourceSpecFlowAssemblyHooksFile)" OutputFile="$(GeneratedSpecFlowAssemblyHooksFile)" TextToReplace="PROJECT_ROOT_NAMESPACE" TextToReplaceWith="$(_SpecFlow_EffectiveRootNamespace.Replace('.', '_'))" />
+    <ReplaceTokenInFileTask Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'" InputFile="$(SourceSpecFlowAssemblyHooksFile)" OutputFile="$(GeneratedSpecFlowAssemblyHooksFile)" TextToReplace="PROJECT_ROOT_NAMESPACE" TextToReplaceWith="$(_SpecFlow_EffectiveRootNamespace.Replace('.', '_'))" WriteOnlyWhenChanged="true" />
     <ItemGroup Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'">
       <Compile Include="$(GeneratedSpecFlowAssemblyHooksFile)"/>
     </ItemGroup>

--- a/SpecFlow.Tools.MsBuild.Generation/ReplaceTokenInFileTask.cs
+++ b/SpecFlow.Tools.MsBuild.Generation/ReplaceTokenInFileTask.cs
@@ -12,12 +12,23 @@ namespace SpecFlow.Tools.MsBuild.Generation
         [Required] public string OutputFile { get; set; }
         [Required] public string TextToReplace { get; set; }
         [Required] public string TextToReplaceWith { get; set; }
+        public bool WriteOnlyWhenChanged { get; set; }
         public override bool Execute()
         {
             try
             {
                 var fileContent = File.ReadAllText(InputFile);
                 var replacedContent = fileContent.Replace(TextToReplace, TextToReplaceWith);
+                if (WriteOnlyWhenChanged && File.Exists(OutputFile))
+                {
+                    var existingContent = File.ReadAllText(OutputFile);
+                    if (replacedContent.Equals(existingContent))
+                    {
+                        Log.LogMessage("Skipping unchanged file {0}", OutputFile);
+                        return true;
+                    }
+                }
+
                 var dir = Path.GetDirectoryName(OutputFile);
                 if (!Directory.Exists(dir))
                 {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Changes after 3.3.74
 
 Changes:
++ Allow incremental builds to work correctly for projects with MSTest/NUnit/xUnit integration
 + Extend FeatureInfo with FolderPath information
 + RuntimePluginTestExecutionLifecycleEvents - allow runtime plugins to subscribe to test execution lifecycle events (similarly to the hooks in binding code)
 + Remove `TestRunEnd` extension point (obsolete with RuntimePluginTestExecutionLifecycleEvents)


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->
This change introduces a property that controls if the ReplaceTokenInFileTask should write the contents if it's not changed. This will improve performance as a project with xunit/nunit/msbuild integration before this fix will trigger a recompile on every build if the file is always changed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
