### PR TITLE
Support dynamic assemblies in container initialization

### DIFF
--- a/TechTalk.SpecFlow/Infrastructure/ContainerBuilder.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContainerBuilder.cs
@@ -141,7 +141,8 @@ namespace TechTalk.SpecFlow.Infrastructure
             var pluginLocator = container.Resolve<IRuntimePluginLocator>();
             var pluginLoader = container.Resolve<IRuntimePluginLoader>();
             var traceListener = container.Resolve<ITraceListener>();
-            foreach (var pluginPath in pluginLocator.GetAllRuntimePlugins(Path.GetDirectoryName(testAssembly?.Location)))
+            var assemblyLocation = testAssembly != null && !testAssembly.IsDynamic ? testAssembly.Location : null;
+            foreach (var pluginPath in pluginLocator.GetAllRuntimePlugins(Path.GetDirectoryName(assemblyLocation)))
             {
                 LoadPlugin(pluginPath, pluginLoader, runtimePluginEvents, unitTestProviderConfigration, traceListener);
             }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/ContainerBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/ContainerBuilderTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using FluentAssertions;
+using Moq;
+using TechTalk.SpecFlow.Infrastructure;
+using TechTalk.SpecFlow.Plugins;
+using Xunit;
+
+namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
+{
+    public class ContainerBuilderTests
+    {
+        [Fact]
+        public void InitializeContainerBuilder_Does_Not_Throw_Exception_For_DynamicAssemblies()
+        {
+            //ARRANGE
+            var containerBuilder = new RuntimeTestsContainerBuilder();
+            var dynamicAssembly = Expression.Lambda(Expression.Empty()).Compile().Method.Module.Assembly;
+
+            //ACT
+            containerBuilder.CreateGlobalContainer(dynamicAssembly);
+
+            //ASSERT NO EXCEPTION
+        }
+    }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+3.4.4
+
+Fixes: 
++ Support dynamic assemblies in container initialization #2110
+
 3.4
 
 Changes:


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


We are generating on-the-fly assemblies containing the tests to be executed. This used to be working in past versions (2.4). Some changes introduced since then prevent us from using our dynamic assemblies successfully.
The reason is that Assembly.Location is retrieved and is not supported by dynamic assemblies (see [here](https://referencesource.microsoft.com/#mscorlib/system/reflection/assembly.cs,1131)).

## Types of changes

- [x] Simply add a test which checks whether the assembly is dynamic before getting its location.
- [x] Add a unit test to see if no exception is thrown when using a dynamic assembly.

## Checklist:

- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation. ⇨ NO
- [x] I have updated the documentation accordingly. ⇨ NO
