### PR TITLE
fixed code example

### DIFF
--- a/docs/Integrations/xUnit.md
+++ b/docs/Integrations/xUnit.md
@@ -30,7 +30,7 @@ using TechTalk.SpecFlow;
 public class BindingClass
 {
     private Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
-    public StepsWithScenarioContext(Xunit.Abstractions.ITestOutputHelper testOutputHelper)
+    public BindingClass(Xunit.Abstractions.ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
     }

--- a/docs/Integrations/xUnit.md
+++ b/docs/Integrations/xUnit.md
@@ -25,6 +25,7 @@ The xUnit ITestOutputHelper is registered in the ScenarioContainer. You can get 
 
 using System;
 using TechTalk.SpecFlow;
+
 [Binding]
 public class BindingClass
 {
@@ -37,7 +38,7 @@ public class BindingClass
     [When(@"I do something")]
     public void WhenIDoSomething()
     {
-        _output.WriteLine("EB7C1291-2C44-417F-ABB7-A5154843BC7B");
+        _testOutputHelper.WriteLine("EB7C1291-2C44-417F-ABB7-A5154843BC7B");
     }
 }
 


### PR DESCRIPTION
- added new line after using statements
- fixed code example
  - used class name as constructor name
  - use instance var in method