### PR TITLE
fix dash symbol in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ in order to craft an excellent pull request:
 
   ```sh
   # Clone your fork of the repo into the current directory
-  git clone –recurse-submodules https://github.com/<your-username>/SpecFlow
+  git clone --recurse-submodules https://github.com/<your-username>/SpecFlow
   # Navigate to the newly cloned directory
   cd SpecFlow
   # Assign the original repo to a remote called "upstream"


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

There was weird symbol inside `Contributing.MD` just before `recurse-submodules`. It was causing weird errors and I could not figure out first what was causing it. I changed it to double dash and it should work again properly.

## Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Other (docs, build config, etc)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
