### PR TITLE
Fix: Testexplorer doesn't show all tests when using tags on examples …

### DIFF
--- a/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
@@ -460,10 +460,14 @@ namespace TechTalk.SpecFlow.Generator.Generation
 
             //_linePragmaHandler.AddLineDirectiveHidden(testMethod.Statements);
             var arguments = paramToIdentifier.Select((p2i, paramIndex) => new KeyValuePair<string, string>(p2i.Key, row.Cells.ElementAt(paramIndex).Value)).ToList();
-            _unitTestGeneratorProvider.SetTestMethodAsRow(generationContext, testMethod, scenarioOutline.Name, exampleSetTitle, variantName, arguments);
-        }
 
-        private CodeMemberMethod CreateTestMethod(
+            // Use the identifier of the example set (e.g. ExampleSet0, ExampleSet1) if we have it.
+            // Otherwise, use the title of the example set provided by the user in the feature file.
+            string exampleSetName = string.IsNullOrEmpty(exampleSetIdentifier) ? exampleSetTitle : exampleSetIdentifier;
+            _unitTestGeneratorProvider.SetTestMethodAsRow(generationContext, testMethod, scenarioOutline.Name, exampleSetName, variantName, arguments);
+		}
+
+		private CodeMemberMethod CreateTestMethod(
             TestClassGenerationContext generationContext,
             StepsContainer scenario,
             IEnumerable<Tag> additionalTags,

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Changes:
 
 Fixes: 
 + Support dynamic assemblies in container initialization #2110
++ Testexplorer doesn't show all tests when using tags on examples in scenario outlines (BUG 9731)
 
 3.4.3
 


### PR DESCRIPTION
…in scenario outlines (BUG 9731)

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->
Fix: Testexplorer doesn't show all tests when using tags on examples in scenario outlines (BUG 9731)

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
