### PR TITLE
Be able to access MSTest TestContext in BeforeTestRun/AfterTestRun #1859

### DIFF
--- a/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/MSTest.AssemblyHooks.template.cs
+++ b/Plugins/TechTalk.SpecFlow.MSTest.Generator.SpecFlowPlugin/build/MSTest.AssemblyHooks.template.cs
@@ -5,6 +5,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics;
 using global::Microsoft.VisualStudio.TestTools.UnitTesting;
 using global::TechTalk.SpecFlow;
+using global::TechTalk.SpecFlow.MSTest.SpecFlowPlugin;
 using global::System.Runtime.CompilerServices;
 
 [GeneratedCode("SpecFlow", "SPECFLOW_VERSION")]
@@ -16,8 +17,9 @@ public class PROJECT_ROOT_NAMESPACE_MSTestAssemblyHooks
     public static void AssemblyInitialize(TestContext testContext)
     {
         var currentAssembly = typeof(PROJECT_ROOT_NAMESPACE_MSTestAssemblyHooks).Assembly;
+        var containerBuilder = new MsTestContainerBuilder(testContext);
 
-        TestRunnerManager.OnTestRunStart(currentAssembly);
+        TestRunnerManager.OnTestRunStart(currentAssembly, containerBuilder);
     }
 
     [AssemblyCleanup]

--- a/Plugins/TechTalk.SpecFlow.MSTest.SpecFlowPlugin/MsTestContainerBuilder.cs
+++ b/Plugins/TechTalk.SpecFlow.MSTest.SpecFlowPlugin/MsTestContainerBuilder.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using BoDi;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TechTalk.SpecFlow.Configuration;
+using TechTalk.SpecFlow.Infrastructure;
+
+namespace TechTalk.SpecFlow.MSTest.SpecFlowPlugin
+{
+    public class MsTestContainerBuilder : IContainerBuilder
+    {
+        private readonly IContainerBuilder _innerContainerBuilder;
+        private readonly TestContext _testContext; 
+
+        public MsTestContainerBuilder(TestContext testContext, IContainerBuilder innerContainerBuilder = null)
+        {
+            _testContext = testContext;
+            _innerContainerBuilder = innerContainerBuilder ?? new ContainerBuilder();
+        }
+
+        public IObjectContainer CreateGlobalContainer(Assembly testAssembly, IRuntimeConfigurationProvider configurationProvider = null)
+        {
+            var container = _innerContainerBuilder.CreateGlobalContainer(testAssembly, configurationProvider);
+            container.RegisterInstanceAs(_testContext);
+
+            return container;
+        }
+
+        public IObjectContainer CreateTestThreadContainer(IObjectContainer globalContainer) => _innerContainerBuilder.CreateTestThreadContainer(globalContainer);
+
+        public IObjectContainer CreateScenarioContainer(IObjectContainer testThreadContainer, ScenarioInfo scenarioInfo)
+            => _innerContainerBuilder.CreateScenarioContainer(testThreadContainer, scenarioInfo);
+
+        public IObjectContainer CreateFeatureContainer(IObjectContainer testThreadContainer, FeatureInfo featureInfo)
+            => _innerContainerBuilder.CreateFeatureContainer(testThreadContainer, featureInfo);
+    }
+}

--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/MsTest/TestContext.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/MsTest/TestContext.feature
@@ -19,3 +19,23 @@ Scenario: Should be able to access TestContext in Steps
     Then the execution summary should contain
         | Succeeded |
         | 1         |
+    
+Scenario: Should be able to access TestContext in BeforeTestRun/AfterTestRun hooks
+    Given there is a SpecFlow project
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """	
+    And the following hook
+        """
+        [BeforeTestRun]
+        public static void BeforeTestRun(BoDi.ObjectContainer objectContainer)
+        {
+            var testContext = objectContainer.Resolve<Microsoft.VisualStudio.TestTools.UnitTesting.TestContext>();
+            testContext.WriteLine(testContext.TestRunDirectory);
+        }
+        """
+    When I execute the tests
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/MsTest/TestContext.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/MsTest/TestContext.feature
@@ -22,10 +22,8 @@ Scenario: Should be able to access TestContext in Steps
     
 Scenario: Should be able to access TestContext in BeforeTestRun/AfterTestRun hooks
     Given there is a SpecFlow project
-    And a scenario 'Simple Scenario' as
-        """
-        When I do something
-        """	
+    And there is a scenario	
+    And all steps are bound and pass
     And the following hook
         """
         [BeforeTestRun]

--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/MsTest/TestContext.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/MsTest/TestContext.feature
@@ -24,12 +24,17 @@ Scenario: Should be able to access TestContext in BeforeTestRun/AfterTestRun hoo
     Given there is a SpecFlow project
     And there is a scenario	
     And all steps are bound and pass
-    And the following hook
+    And the following hooks
         """
         [BeforeTestRun]
-        public static void BeforeTestRun(BoDi.ObjectContainer objectContainer)
+        public static void BeforeTestRun(Microsoft.VisualStudio.TestTools.UnitTesting.TestContext testContext)
         {
-            var testContext = objectContainer.Resolve<Microsoft.VisualStudio.TestTools.UnitTesting.TestContext>();
+            testContext.WriteLine(testContext.TestRunDirectory);
+        }
+
+        [AfterTestRun]
+        public static void AfterTestRun(Microsoft.VisualStudio.TestTools.UnitTesting.TestContext testContext)
+        {
             testContext.WriteLine(testContext.TestRunDirectory);
         }
         """

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 
 Features:
 + Add possibility to have a custom pending step message https://github.com/SpecFlowOSS/SpecFlow/issues/1382
++ Be able to access MSTest TestContext in BeforeTestRun/AfterTestRun hook https://github.com/SpecFlowOSS/SpecFlow/issues/1859
 
 Fixes:
 + Copy specflow.json to the output directory

--- a/docs/Integrations/MsTest.md
+++ b/docs/Integrations/MsTest.md
@@ -1,6 +1,6 @@
 # MSTest
 
-SpecFlow does support MsTest V2. It is not any more working with the old MsTest V1.
+SpecFlow supports MsTest V2.
 
 Documentation for MSTest can be found [here](https://docs.microsoft.com/en-us/visualstudio/test/unit-test-your-code?view=vs-2019).
 
@@ -17,9 +17,12 @@ For Test Discovery & Execution:
 
 ## Accessing TestContext
 
+You can access the MsTest TestContext instance in your step definition or hook classes by constructor injection:
+
 ``` csharp
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[Binding]
 public class MyStepDefs
 {
     private readonly TestContext _testContext;
@@ -28,11 +31,44 @@ public class MyStepDefs
         _testContext = testContext;
     }
 
+    [Given("a step")]
+    public void GivenAStep()
+    {
+        //you can access the TestContext injected in the ctor
+        _testContext.WriteLine(_testContext.TestRunDirectory);
+    }
+
+
     [BeforeScenario()]
     public void BeforeScenario()
     {
-        //now you can access the TestContext
+        //you can access the TestContext injected in the ctor
+        _testContext.WriteLine(_testContext.TestRunDirectory);
     } 
+}
+```
+
+In the static BeforeTestRun/AfterTestRun hooks you can use parameter injection:
+
+``` csharp
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[Binding]
+public class Hooks
+{
+    [BeforeTestRun]
+    public static void BeforeTestRun(TestContext testContext)
+    {
+        //you can access the TestContext injected as parameter
+        testContext.WriteLine(testContext.TestRunDirectory);
+    }
+
+    [AfterTestRun]
+    public static void AfterTestRun(TestContext testContext)
+    {
+        //you can access the TestContext injected as parameter
+        testContext.WriteLine(testContext.DeploymentDirectory);
+    }
 }
 ```
 


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->
PR for issue #1859 

This feature enables access to the TestContext in the BeforeTestRun/AfterTestRun simply via parameter injection:
``` csharp
    [BeforeTestRun]
    public static void BeforeTestRun(TestContext testContext)
    {
        //you can access the TestContext injected as parameter
        testContext.WriteLine(testContext.TestRunDirectory);
    }
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
