### PR TITLE
Fix the SpecFlow reference in the ExternalData plugin

### DIFF
--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/SpecFlow.ExternalData.SpecFlowPlugin.csproj
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/SpecFlow.ExternalData.SpecFlowPlugin.csproj
@@ -15,6 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="SpecFlow.CustomPlugin" Version="3.5.14" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\TechTalk.SpecFlow.Generator\TechTalk.SpecFlow.Generator.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reference the Generator project directly to avoid version conflicts with the SpecFlow.dll in the generated nuget packages

Fixes #2218 

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
