### PR TITLE
#2307 Fixed bug when feature context can't be resolved at static methods

### DIFF
--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacTestObjectResolver.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacTestObjectResolver.cs
@@ -9,8 +9,12 @@ namespace SpecFlow.Autofac
     {
         public object ResolveBindingInstance(Type bindingType, IObjectContainer scenarioContainer)
         {
-            var componentContext = scenarioContainer.Resolve<IComponentContext>();
-            return componentContext.Resolve(bindingType);
+            if (scenarioContainer.IsRegistered<IComponentContext>())
+            {
+                var componentContext = scenarioContainer.Resolve<IComponentContext>();
+                return componentContext.Resolve(bindingType);
+            }
+            return scenarioContainer.Resolve(bindingType);
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Fixes:
 + Cleanup scenario context even after an AfterScenario hook error
 + Load RuntimePlugins to the same AssemblyLoadContext
 + Capture hook errors and call plugin hooks after hook error
++ Fixed context injection in static methods for Autofac plugin https://github.com/SpecFlowOSS/SpecFlow/issues/2307
 
 Changes:
 + Ignore tag handling: generate test framework specific ignore attributes 


### PR DESCRIPTION
Fix for #2307 .
This PR only solves the problem with injecting contexts in static hooks (i.e. AfterFeature)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
