### PR TITLE
improve RuntimePlugin Locator and LocationMerger

### DIFF
--- a/TechTalk.SpecFlow/Plugins/RuntimePluginLoader.cs
+++ b/TechTalk.SpecFlow/Plugins/RuntimePluginLoader.cs
@@ -29,7 +29,7 @@ namespace TechTalk.SpecFlow.Plugins
                 return null;
             }
 
-            if (!typeof(IRuntimePlugin).IsAssignableFrom((pluginAttribute.PluginType)))
+            if (!typeof(IRuntimePlugin).IsAssignableFrom(pluginAttribute.PluginType))
                 throw new SpecFlowException(string.Format("Invalid plugin attribute in {0}. Plugin type must implement IRuntimePlugin. Please check https://go.specflow.org/doc-plugins for details.", assembly.FullName));
 
             IRuntimePlugin plugin;

--- a/TechTalk.SpecFlow/Plugins/RuntimePluginLocationMerger.cs
+++ b/TechTalk.SpecFlow/Plugins/RuntimePluginLocationMerger.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace TechTalk.SpecFlow.Plugins
 {
@@ -8,11 +7,47 @@ namespace TechTalk.SpecFlow.Plugins
     {
         public IReadOnlyList<string> Merge(IReadOnlyList<string> pluginPaths)
         {
-            var merge = from entry in pluginPaths
-                        group entry by Path.GetFileName(entry)
-                into g
-                        select g.FirstOrDefault();
-            return merge.ToList();
+            // Idea is to filter out the same assemblies stored on different paths. Shortcut: check if we even have duplicated assemblies
+            var hashset = new HashSet<string>(
+#if NETCOREAPP2_1_OR_GREATER
+                // initialize with expected size when available
+                pluginPaths.Count
+#endif
+                );
+
+            List<string> modifiedList = null;
+            for (var i = 0; i < pluginPaths.Count; i++)
+            {
+                if (hashset.Add(Path.GetFileName(pluginPaths[i])))
+                {
+                    // Assembly not duplicated
+                    if (modifiedList is null)
+                    {
+                        // No duplication yet, continue
+                        continue;
+                    }
+
+                    // We already had a duplication, fill the list with this non duplicated entry
+                    modifiedList.Add(pluginPaths[i]);
+                }
+                else if (modifiedList is null)
+                {
+                    // First duplicated assembly, Copy all previous entry into the new list
+                    modifiedList = CopyUntilIndex(pluginPaths, i);
+                }
+            }
+
+            return modifiedList ?? pluginPaths;
+        }
+
+        private static List<string> CopyUntilIndex(IReadOnlyList<string> pluginPaths, int index)
+        {
+            var result = new List<string>(pluginPaths.Count);
+            for (var i = 0; i < index; i++)
+            {
+                result.Add(pluginPaths[i]);
+            }
+            return result;
         }
     }
 }

--- a/TechTalk.SpecFlow/StringExtensions.cs
+++ b/TechTalk.SpecFlow/StringExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace TechTalk.SpecFlow
 {
-	internal static class StringExtensions
+    internal static class StringExtensions
     {
         internal static bool IsNullOrEmpty(this string value)
         {
@@ -14,19 +14,12 @@
 
         internal static bool IsNullOrWhiteSpace(this string value)
         {
-            if (value == null) return true;
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (!char.IsWhiteSpace(value[i])) return false;
-            }
-
-            return true;
+            return string.IsNullOrWhiteSpace(value);
         }
 
         internal static bool IsNotNullOrWhiteSpace(this string value)
         {
-            return !value.IsNullOrWhiteSpace();
+            return !string.IsNullOrWhiteSpace(value);
         }
 
         internal static string StripWhitespaces(this string value)

--- a/Tests/TechTalk.SpecFlow.PluginTests/RuntimePluginLocatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.PluginTests/RuntimePluginLocatorTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using FluentAssertions;
-using Moq;
 using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Plugins;
 using Xunit;
@@ -28,7 +27,7 @@ namespace TechTalk.SpecFlow.PluginTests
             var plugins = runtimePluginLocator.GetAllRuntimePlugins();
 
             //ASSERT
-            plugins.Any(plugin => plugin.Equals(testAssembly.Location)).Should().BeTrue();
+            plugins.Should().Contain(testAssembly.Location);
         }
 
         [Fact]
@@ -54,9 +53,8 @@ namespace TechTalk.SpecFlow.PluginTests
             generatorPluginsFound.Count.Should().Be(numberOfGeneratorPlugins);
 
             var numberOfRuntimePlugins = NumberOfRuntimePluginsReferenced(projectReferences);
-            var runtimePluginsFound = plugins.Where(p => !p.Equals(testAssembly.Location))
-                                        .Except(generatorPluginsFound).ToList();
-            runtimePluginsFound.Count.Should().Be(numberOfRuntimePlugins, $"{string.Join(",", runtimePluginsFound)} were found");
+            var runtimePluginsFound = plugins.Where(p => !p.Equals(testAssembly.Location)).Except(generatorPluginsFound).ToList();
+            runtimePluginsFound.Should().HaveCount(numberOfRuntimePlugins, $"{string.Join(",", runtimePluginsFound)} were found");
         }
 
         private int NumberOfGeneratorPluginsReferenced(List<string> projectReferences)

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Fixes:
 + Before Feature hooks should not be executed when the feature is ignored https://github.com/SpecFlowOSS/SpecFlow/issues/2234
 + Cleanup scenario context even after an AfterScenario hook error
 + Load RuntimePlugins to the same AssemblyLoadContext
++ Improve performance / Reduce allocations of RuntimePluginLocator & LocationMerger
 + Capture hook errors and call plugin hooks after hook error
 + Fixed context injection in static methods for Autofac plugin https://github.com/SpecFlowOSS/SpecFlow/issues/2307
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+After 3.7.38
+
+Fixes:
++ Improve performance / Reduce allocations of RuntimePluginLocator & LocationMerger
+
 3.7
 
 Features:
@@ -9,7 +14,6 @@ Fixes:
 + Before Feature hooks should not be executed when the feature is ignored https://github.com/SpecFlowOSS/SpecFlow/issues/2234
 + Cleanup scenario context even after an AfterScenario hook error
 + Load RuntimePlugins to the same AssemblyLoadContext
-+ Improve performance / Reduce allocations of RuntimePluginLocator & LocationMerger
 + Capture hook errors and call plugin hooks after hook error
 + Fixed context injection in static methods for Autofac plugin https://github.com/SpecFlowOSS/SpecFlow/issues/2307
 


### PR DESCRIPTION
Improves the logic in RuntimePluginLocator by 
- checking whether we already added the target directory before searching for files on the filesystem
- avoiding various temporary allocations

Improves the logic in RuntimePluginLocationMerger by
- reducing allocations in the common case

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [x] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Evidence:
I've profiled the existing test called RuntimePluginLocatorTests.LoadPlugins_Find_TestAssembly to test improvements.

Before:
![image](https://user-images.githubusercontent.com/2437596/110772033-79adcc00-825b-11eb-95d1-2e3f93089467.png)
After:
![image](https://user-images.githubusercontent.com/2437596/110772054-7f0b1680-825b-11eb-8c3a-e0efe8b1ca7c.png)

Things to look for:
- Takes overall less time (7ms -> 2 ms) (Keep in mind this is under a profiler)
- SearchPluginsInFolder is only called once instead of 3 times (due to all 3 directories being the same)
- Merger does not have a static constructor being called anymore and overall reduced time (due to not some Linq functions)
- IsNotNullOrWhiteSpace is much faster (due to the framework methods being already fully optimized by the JIT)

Sidenote:
The bigger the target directory is to look in, the slower it gets / the better the new solution will perform.
Example performance of a directory with ~90 files in:
![image](https://user-images.githubusercontent.com/2437596/110773046-9991bf80-825c-11eb-81bb-59c0982d3ebf.png)

