### PR TITLE
remove linq from hot paths

### DIFF
--- a/TechTalk.SpecFlow/Bindings/StepContext.cs
+++ b/TechTalk.SpecFlow/Bindings/StepContext.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using TechTalk.SpecFlow.Compatibility;
 using TechTalk.SpecFlow.Configuration;
 
@@ -24,16 +24,62 @@ namespace TechTalk.SpecFlow.Bindings
 
         public StepContext(FeatureInfo featureInfo, ScenarioInfo scenarioInfo)
         {
-            Language = featureInfo == null ? CultureInfoHelper.GetCultureInfo(ConfigDefaults.FeatureLanguage) : featureInfo.Language;
-            FeatureTitle = featureInfo == null ? null : featureInfo.Title;
-            ScenarioTitle = scenarioInfo == null ? null : scenarioInfo.Title; 
+            if (featureInfo is not null)
+            {
+                Language = featureInfo.Language;
+                FeatureTitle = featureInfo.Title;
 
-            var tags = Enumerable.Empty<string>();
-            if (featureInfo != null && featureInfo.Tags != null)
-                tags = tags.Concat(featureInfo.Tags);
-            if (scenarioInfo != null && scenarioInfo.Tags != null)
-                tags = tags.Concat(scenarioInfo.Tags).Distinct();
-            Tags = tags;
+                if (scenarioInfo is not null)
+                {
+                    ScenarioTitle = scenarioInfo.Title;
+
+                    string[] featureTags = featureInfo.Tags;
+                    string[] scenarioTags = scenarioInfo.Tags;
+                    if (featureTags is null || featureTags.Length == 0)
+                    {
+                        Tags = scenarioTags ?? Array.Empty<string>();
+                    }
+                    else
+                    {
+                        if (scenarioTags is null || scenarioTags.Length == 0)
+                        {
+                            Tags = featureTags;
+                        }
+                        else
+                        {
+                            Tags = CombineTags(featureInfo.Tags, scenarioInfo.Tags);
+                        }
+                    }
+                }
+                else
+                {
+                    Tags = featureInfo.Tags ?? Array.Empty<string>();
+                }
+            }
+            else
+            {
+                Language = CultureInfoHelper.GetCultureInfo(ConfigDefaults.FeatureLanguage);
+                if (scenarioInfo is null)
+                {
+                    Tags = Array.Empty<string>();
+                }
+                else
+                {
+                    ScenarioTitle = scenarioInfo.Title;
+                    Tags = scenarioInfo.Tags ?? Array.Empty<string>();
+                }
+            }
+        }
+
+        private static IEnumerable<string> CombineTags(string[] featureTags, string[] scenarioTags)
+        {
+            var result = new HashSet<string>(featureTags);
+            foreach (string tag in scenarioTags)
+            {
+                result.Add(tag);
+            }
+
+            return result;
         }
     }
 }

--- a/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using BoDi;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Tracing;
@@ -10,7 +8,7 @@ namespace TechTalk.SpecFlow.Infrastructure
 {
     public class ContextManager : IContextManager, IDisposable
     {
-        private class InternalContextManager<TContext>: IDisposable where TContext : SpecFlowContext
+        private sealed class InternalContextManager<TContext>: IDisposable where TContext : SpecFlowContext
         {
             private readonly ITestTracer testTracer;
             private TContext instance;
@@ -70,7 +68,7 @@ namespace TechTalk.SpecFlow.Infrastructure
         /// correctly even when there is a nesting of steps calling steps calling steps.
         /// </summary>
         /// <typeparam name="TContext">A type derived from SpecFlowContext, which needs to be managed  in a way</typeparam>
-        private class StackedInternalContextManager<TContext> : IDisposable where TContext : SpecFlowContext
+        private sealed class StackedInternalContextManager<TContext> : IDisposable where TContext : SpecFlowContext
         {
             private readonly ITestTracer testTracer;
             private readonly Stack<TContext> instances = new Stack<TContext>();
@@ -85,11 +83,11 @@ namespace TechTalk.SpecFlow.Infrastructure
                 get { return IsEmpty ? null : instances.Peek(); }
             }
 
-            public bool IsEmpty => !instances.Any();
+            public bool IsEmpty => instances.Count == 0;
 
             public void Push(TContext newInstance)
             {
-                instances.Push(newInstance);                
+                instances.Push(newInstance);
             }
 
             public void RemoveTop()


### PR DESCRIPTION
This PR contains 2 main changes:
- sealing types in ContextManager and removing LINQ from IsEmpty (!stack.Any() is equal to stack.Count == 0, but much faster and inlineable)
- reducing allocation and improving performance in StepContext Ctor by removing LINQ

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [x] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Comments
- Do you want proof of every change?
- I like to add `#nullable enable` to every class, is this fine for you? (see [Nullable Reference Types](https://devblogs.microsoft.com/dotnet/nullable-reference-types-in-csharp/))