### PR TITLE
improve CultureInfoScope

### DIFF
--- a/TechTalk.SpecFlow/Bindings/BindingInvoker.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingInvoker.cs
@@ -91,12 +91,7 @@ namespace TechTalk.SpecFlow.Bindings
 
         protected virtual CultureInfoScope CreateCultureInfoScope(IContextManager contextManager)
         {
-            var cultureInfo = CultureInfo.CurrentCulture;
-            if (contextManager.FeatureContext != null)
-            {
-                cultureInfo = contextManager.FeatureContext.BindingCulture;
-            }
-            return new CultureInfoScope(cultureInfo);
+            return new CultureInfoScope(contextManager.FeatureContext);
         }
 
         protected void EnsureReflectionInfo(IBinding binding, out MethodInfo methodInfo, out Delegate bindingAction)

--- a/TechTalk.SpecFlow/CultureInfoScope.cs
+++ b/TechTalk.SpecFlow/CultureInfoScope.cs
@@ -5,27 +5,36 @@ using TechTalk.SpecFlow.Tracing;
 
 namespace TechTalk.SpecFlow
 {
-    public class CultureInfoScope : IDisposable
+    public readonly struct CultureInfoScope : IDisposable
     {
         private readonly CultureInfo originalCultureInfo;
 
-        public CultureInfoScope(CultureInfo cultureInfo)
+        public CultureInfoScope(FeatureContext featureContext)
         {
-            if (cultureInfo != null && !cultureInfo.Equals(Thread.CurrentThread.CurrentCulture))
+            originalCultureInfo = null;
+            var cultureInfo = featureContext?.BindingCulture;
+            if (cultureInfo is not null)
             {
-                if (cultureInfo.IsNeutralCulture)
+                var current = Thread.CurrentThread.CurrentCulture;
+                if (!cultureInfo.Equals(current))
                 {
-                    cultureInfo = LanguageHelper.GetSpecificCultureInfo(cultureInfo);
+                    if (cultureInfo.IsNeutralCulture)
+                    {
+                        cultureInfo = LanguageHelper.GetSpecificCultureInfo(cultureInfo);
+                    }
+
+                    originalCultureInfo = current;
+                    Thread.CurrentThread.CurrentCulture = cultureInfo;
                 }
-                originalCultureInfo = Thread.CurrentThread.CurrentCulture;
-                Thread.CurrentThread.CurrentCulture = cultureInfo;
             }
         }
 
         public void Dispose()
         {
-            if (originalCultureInfo != null)
+            if (originalCultureInfo is not null)
+            {
                 Thread.CurrentThread.CurrentCulture = originalCultureInfo;
+            }
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/CultureInfoScopeTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/CultureInfoScopeTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Globalization;
+using System.Threading;
+using TechTalk.SpecFlow.Configuration;
+using Xunit;
+
+namespace TechTalk.SpecFlow.RuntimeTests.Bindings
+{
+    public class CultureInfoScopeTests
+    {
+        [Fact]
+        public void DoesNothing_WhenContextIsNull()
+        {
+            FeatureContext context = null;
+
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            using (new CultureInfoScope(context))
+            {
+                Assert.Equal(currentCulture, Thread.CurrentThread.CurrentCulture);
+            }
+            Assert.Equal(currentCulture, Thread.CurrentThread.CurrentCulture);
+        }
+
+        [Fact]
+        public void DoesNothing_WhenCultureIsCurrent()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            FeatureContext context = GetFeatureContext(currentCulture);
+
+            using (new CultureInfoScope(context))
+            {
+                Assert.Equal(currentCulture, Thread.CurrentThread.CurrentCulture);
+            }
+            Assert.Equal(currentCulture, Thread.CurrentThread.CurrentCulture);
+        }
+
+        [Fact]
+        public void SwapsCultureInfo_WhenCultureDifferent()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var replaceCulture = new CultureInfo("IT-it");
+            FeatureContext context = GetFeatureContext(replaceCulture);
+
+            using (new CultureInfoScope(context))
+            {
+                Assert.Equal(replaceCulture, Thread.CurrentThread.CurrentCulture);
+            }
+            Assert.Equal(currentCulture, Thread.CurrentThread.CurrentCulture);
+        }
+
+        private static FeatureContext GetFeatureContext(CultureInfo cultureInfo)
+        {
+            return new FeatureContext(default,
+                                      new FeatureInfo(cultureInfo, default, default, default),
+                                      new SpecFlowConfiguration(default, default, default, default, cultureInfo, default, default, default, default, default, default, default, default, default, default, default, default, default));
+        }
+    }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 After 3.7.38
 
 Fixes:
++ Change CultureInfoScope to readonly struct
 + Improve performance / Reduce allocations of RuntimePluginLocator & LocationMerger
 + Fix spelling of IRuntimePluginTestExecutionLifecycleEventEmitter.RaiseExecutionLifecycleEvent
 


### PR DESCRIPTION
Changes the CultureInfoScope to a readonly struct to avoid an extra allocation.
Also slightly improve performance by only reading the current cultureInfo only once instead of multiple times.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
