### PR TITLE
improve performance / reduce allocations of FireEvents

### DIFF
--- a/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace TechTalk.SpecFlow.Bindings.Reflection
 {
@@ -104,6 +105,12 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             if (reflectionBindingMethod == null)
                 throw new SpecFlowException("The binding method cannot be used for reflection: " + bindingMethod);
             return reflectionBindingMethod.MethodInfo;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static T[] AsArray<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable as T[] ?? enumerable.ToArray();
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingMethod.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingMethod.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace TechTalk.SpecFlow.Bindings.Reflection
@@ -7,10 +7,12 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
     public class RuntimeBindingMethod : IBindingMethod
     {
         public readonly MethodInfo MethodInfo;
+        private RuntimeBindingType runtimeBindingType;
+        private IBindingParameter[] _parameters;
 
         public IBindingType Type
         {
-            get { return new RuntimeBindingType(MethodInfo.DeclaringType); }
+            get { return runtimeBindingType ??= new RuntimeBindingType(MethodInfo.DeclaringType); }
         }
 
         public IBindingType ReturnType
@@ -25,12 +27,29 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public IEnumerable<IBindingParameter> Parameters
         {
-            get { return MethodInfo.GetParameters().Select(pi => (IBindingParameter)new RuntimeBindingParameter(pi)); }
+            get { return _parameters ??= GetParameters(); }
         }
 
         public RuntimeBindingMethod(MethodInfo methodInfo)
         {
-            this.MethodInfo = methodInfo;
+            MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+        }
+
+        private IBindingParameter[] GetParameters()
+        {
+            var parameters = MethodInfo.GetParameters();
+            if (parameters.Length == 0)
+            {
+                return Array.Empty<IBindingParameter>();
+            }
+
+            var result = new IBindingParameter[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                result[i] = new RuntimeBindingParameter(parameters[i]);
+            }
+
+            return result;
         }
 
         public override string ToString()
@@ -53,7 +72,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public override int GetHashCode()
         {
-            return (MethodInfo != null ? MethodInfo.GetHashCode() : 0);
+            return MethodInfo.GetHashCode();
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingParameter.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingParameter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 
 namespace TechTalk.SpecFlow.Bindings.Reflection
@@ -5,10 +6,11 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
     public class RuntimeBindingParameter : IBindingParameter
     {
         private readonly ParameterInfo parameterInfo;
+        private RuntimeBindingType runtimeBindingType;
 
         public IBindingType Type
         {
-            get { return new RuntimeBindingType(parameterInfo.ParameterType); }
+            get { return runtimeBindingType ??= new RuntimeBindingType(parameterInfo.ParameterType); }
         }
 
         public string ParameterName
@@ -18,7 +20,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public RuntimeBindingParameter(ParameterInfo parameterInfo)
         {
-            this.parameterInfo = parameterInfo;
+            this.parameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
         }
 
         public override string ToString()
@@ -41,7 +43,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public override int GetHashCode()
         {
-            return (parameterInfo != null ? parameterInfo.GetHashCode() : 0);
+            return parameterInfo.GetHashCode();
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public RuntimeBindingType(Type type)
         {
-            this.Type = type;
+            Type = type ?? throw new ArgumentNullException(nameof(type));
         }
 
         public bool IsAssignableTo(IBindingType baseType)
@@ -42,7 +42,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public override int GetHashCode()
         {
-            return (Type != null ? Type.GetHashCode() : 0);
+            return Type.GetHashCode();
         }
 
         public static readonly RuntimeBindingType Void = new RuntimeBindingType(typeof(void));

--- a/TechTalk.SpecFlow/Bindings/StepArgumentTypeConverter.cs
+++ b/TechTalk.SpecFlow/Bindings/StepArgumentTypeConverter.cs
@@ -73,7 +73,7 @@ namespace TechTalk.SpecFlow.Bindings
         {
             var match = stepTransformation.Regex.Match(stepSnippet);
             var argumentStrings = match.Groups.Cast<Group>().Skip(1).Select(g => g.Value);
-            var bindingParameters = stepTransformation.Method.Parameters.ToArray();
+            var bindingParameters = stepTransformation.Method.Parameters.AsArray();
             return argumentStrings
                 .Select((arg, argIndex) => this.Convert(arg, bindingParameters[argIndex].Type, cultureInfo))
                 .ToArray();

--- a/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
+++ b/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
@@ -43,7 +43,7 @@ namespace TechTalk.SpecFlow.Bindings
             string methodName = bindingMethod.Name;
             methodName = RemoveStepPrefix(stepDefinitionType, methodName);
 
-            var parameters = bindingMethod.Parameters.ToArray();
+            var parameters = bindingMethod.Parameters.AsArray();
 
             int processedPosition = 0;
             var reBuilder = new StringBuilder("(?i)");

--- a/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
+++ b/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
@@ -81,7 +81,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             if (useParamMatching)
             {
                 Debug.Assert(match != null); // useParamMatching -> useRegexMatching
-                var bindingParameters = stepDefinitionBinding.Method.Parameters.ToArray();
+                var bindingParameters = stepDefinitionBinding.Method.Parameters.AsArray();
 
                 // check if the regex + extra arguments match to the binding method parameters
                 if (arguments.Length != bindingParameters.Length)


### PR DESCRIPTION
Various improvements around FireEvents

BindingRegistry
- Change from List to Hashset to store Hookbindings for faster storage
- reduced closure allocations by removing LINQ

RuntimeBinding*
- Caching of lazy created objects like Parameter or Type
- AsArray extension method => Avoid calling ToArray if it is already an array to reduce allocation
- Throw on null in constructor and avoid check for null in hashcode (less branches equals faster hashcode)

TestExecutionEngine
- Removed unused fields
- GetExecuteArguments / ResolveArguments: remove LINQ and shortcut 0 length arguments
- FireEvents: Shortcut no / one hook invoke path. Reduce / delay allocations where possible

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [x] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Proof [Before / After]
FireEvents
![FireEvents Before](https://user-images.githubusercontent.com/2437596/113356804-294df980-9343-11eb-9ab1-15341f03abe3.png)
![FireEvents After](https://user-images.githubusercontent.com/2437596/113356807-2a7f2680-9343-11eb-9026-3072affb8b21.png)

GetExecuteArguments
![GetExecuteArguments Before](https://user-images.githubusercontent.com/2437596/113356861-3cf96000-9343-11eb-95d0-9a6563820dac.png)
![GetExecuteArguments After](https://user-images.githubusercontent.com/2437596/113356864-3ec32380-9343-11eb-9c84-3cdfaf0fbf96.png)

ResolveArguments
![ResolveArguments Before](https://user-images.githubusercontent.com/2437596/113356873-4387d780-9343-11eb-8076-0dbe05a92be7.png)
![ResolveArguments After](https://user-images.githubusercontent.com/2437596/113356878-45519b00-9343-11eb-9a77-c95f2b246e66.png)

