### PR TITLE
Fix WhiteSource Bolt reporting

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -121,4 +121,5 @@ jobs:
 
   - task: WhiteSource Bolt@20
     displayName: 'WhiteSource Bolt'
+    condition: eq('${{ parameters.name }}', 'Windows')
     timeoutInMinutes: 5

--- a/build.yml
+++ b/build.yml
@@ -122,4 +122,5 @@ jobs:
   - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@19
     displayName: 'WhiteSource Bolt'
     inputs:
-      advance: true 
+      advance: true
+    timeoutInMinutes: 5

--- a/build.yml
+++ b/build.yml
@@ -119,8 +119,6 @@ jobs:
       artifactType: container
       ArtifactName: 'SpecFlow.CI-Binlogs-${{ parameters.name }}'
 
-  - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@19
+  - task: WhiteSource Bolt@20
     displayName: 'WhiteSource Bolt'
-    inputs:
-      advance: true
     timeoutInMinutes: 5


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

WhiteSource Bolt is not reporting since December 2019. As I found out the problem was that we are using an older version of the WS Bolt build task. After updating it to the latest (version 20), it works again.
I added a condition to scan the Open Source Components only during the Windows build (no value to scan the same stuff for Linux as well). Also I added a timeout to the WhiteSource Bolt task, because there are builds where the WS Bolt task took 30 mins to complete (and even after that time it was timed out).

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
