### PR TITLE
Add null check for DependencyContext

### DIFF
--- a/TechTalk.SpecFlow/Plugins/PluginAssemblyResolver.cs
+++ b/TechTalk.SpecFlow/Plugins/PluginAssemblyResolver.cs
@@ -44,7 +44,7 @@ namespace TechTalk.SpecFlow.Plugins
 
         private Assembly OnResolving(AssemblyLoadContext context, AssemblyName name)
         {
-            var library = _dependencyContext.RuntimeLibraries.FirstOrDefault(
+            var library = _dependencyContext?.RuntimeLibraries.FirstOrDefault(
                 runtimeLibrary => string.Equals(runtimeLibrary.Name, name.Name, StringComparison.OrdinalIgnoreCase));
 
             if (library != null)

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Fixes:
 + Update to NUnit 3.13.1 as minimum NUnit version
 + Step argument transformations should not be executed if a previous step had an error https://github.com/SpecFlowOSS/SpecFlow/issues/2382
 + Update "dotnet new" template in sync with the Visual Studio template
++ Fix NullReferenceException during assembly loading in PluginAssemblyResolver #2344 #2403
 
 
 3.7


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

During the Assembly's `OnResolving` method the `_dependencyContext` can be null, so check for that.

Fixes #2344 #2403 

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
