### PR TITLE
introduce and use TagHelper in UnitTestGeneration

### DIFF
--- a/TechTalk.SpecFlow.Generator/Generation/GeneratorConstants.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/GeneratorConstants.cs
@@ -17,6 +17,6 @@
         public const string SCENARIO_OUTLINE_EXAMPLE_TAGS_PARAMETER = "exampleTags";
         public const string SCENARIO_TAGS_VARIABLE_NAME = "tagsOfScenario";
         public const string SCENARIO_ARGUMENTS_VARIABLE_NAME = "argumentsOfScenario";
-        public const string FEATURE_TAGS_VARIABLE_NAME = "_featureTags";
+        public const string FEATURE_TAGS_VARIABLE_NAME = "featureTags";
     }
 }

--- a/TechTalk.SpecFlow.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -116,7 +116,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
         {
             var scenarioCleanupMethod = generationContext.ScenarioCleanupMethod;
 
-            scenarioCleanupMethod.Attributes = MemberAttributes.Public;
+            scenarioCleanupMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             scenarioCleanupMethod.Name = GeneratorConstants.SCENARIO_CLEANUP_NAME;
 
             // call collect errors
@@ -146,6 +146,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
             }
 
             var featureTagsField = new CodeMemberField(typeof(string[]), GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME);
+            featureTagsField.Attributes |= MemberAttributes.Static;
             featureTagsField.InitExpression = _scenarioPartHelper.GetStringArrayExpression(generationContext.Feature.Tags);
 
             generationContext.TestClass.Members.Add(featureTagsField);
@@ -195,7 +196,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
                         new CodeFieldReferenceExpression(
                             new CodeTypeReferenceExpression("ProgrammingLanguage"),
                             _codeDomHelper.TargetLanguage.ToString()),
-                        _scenarioPartHelper.GetStringArrayExpression(generationContext.Feature.Tags))));
+                        new CodeFieldReferenceExpression(null, GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME))));
 
             //testRunner.OnFeatureStart(featureInfo);
             testClassInitializeMethod.Statements.Add(
@@ -232,7 +233,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
         {
             var testInitializeMethod = generationContext.TestInitializeMethod;
 
-            testInitializeMethod.Attributes = MemberAttributes.Public;
+            testInitializeMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             testInitializeMethod.Name = GeneratorConstants.TEST_INITIALIZE_NAME;
 
             _testGeneratorProvider.SetTestInitializeMethod(generationContext);
@@ -242,7 +243,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
         {
             var testCleanupMethod = generationContext.TestCleanupMethod;
 
-            testCleanupMethod.Attributes = MemberAttributes.Public;
+            testCleanupMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             testCleanupMethod.Name = GeneratorConstants.TEST_CLEANUP_NAME;
 
             _testGeneratorProvider.SetTestCleanupMethod(generationContext);
@@ -259,7 +260,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
         {
             var scenarioInitializeMethod = generationContext.ScenarioInitializeMethod;
 
-            scenarioInitializeMethod.Attributes = MemberAttributes.Public;
+            scenarioInitializeMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             scenarioInitializeMethod.Name = GeneratorConstants.SCENARIO_INITIALIZE_NAME;
             scenarioInitializeMethod.Parameters.Add(
                 new CodeParameterDeclarationExpression(typeof(ScenarioInfo), "scenarioInfo"));
@@ -277,7 +278,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
         {
             var scenarioStartMethod = generationContext.ScenarioStartMethod;
 
-            scenarioStartMethod.Attributes = MemberAttributes.Public;
+            scenarioStartMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             scenarioStartMethod.Name = GeneratorConstants.SCENARIO_START_NAME;
 
             //testRunner.OnScenarioStart();

--- a/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
@@ -169,7 +169,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
                         new CodePrimitiveExpression(scenario.Description),
                         new CodeVariableReferenceExpression(GeneratorConstants.SCENARIO_TAGS_VARIABLE_NAME),
                         new CodeVariableReferenceExpression(GeneratorConstants.SCENARIO_ARGUMENTS_VARIABLE_NAME),
-                        new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME))));
+                        new CodeFieldReferenceExpression(null, GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME))));
 
             GenerateScenarioInitializeCall(generationContext, scenario, testMethod);
 
@@ -239,47 +239,24 @@ namespace TechTalk.SpecFlow.Generator.Generation
                 _scenarioPartHelper.GenerateStep(generationContext, statementsWhenScenarioIsExecuted, scenarioStep, paramToIdentifier);
             }
 
-            var isScenarioIgnoredVariable = new CodeVariableDeclarationStatement(typeof(bool), "isScenarioIgnored", new CodeDefaultValueExpression(new CodeTypeReference(typeof(bool))));
-            var isFeatureIgnoredVariable = new CodeVariableDeclarationStatement(typeof(bool), "isFeatureIgnored", new CodeDefaultValueExpression(new CodeTypeReference(typeof(bool))));
-            testMethod.Statements.Add(isScenarioIgnoredVariable);
-            testMethod.Statements.Add(isFeatureIgnoredVariable);
-
-
             var tagsOfScenarioVariableReferenceExpression = new CodeVariableReferenceExpression("tagsOfScenario");
-            var isScenarioIgnoredVariableReferenceExpression = new CodeVariableReferenceExpression("isScenarioIgnored");
-            var featureFileTagFieldReferenceExpression = new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME);
-            var isFeatureIgnoredVariableReferenceExpression = new CodeVariableReferenceExpression("isFeatureIgnored");
+            var featureFileTagFieldReferenceExpression = new CodeFieldReferenceExpression(null, GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME);
 
-            var ignoreLinqStatement = "Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, \"ignore\", StringComparison.CurrentCultureIgnoreCase)).Any";
-            if (_codeDomHelper.TargetLanguage == CodeDomProviderLanguage.VB)
-            {
-                ignoreLinqStatement = "Where(Function(__entry) __entry IsNot Nothing).Where(Function(__entry) String.Equals(__entry, \"ignore\", StringComparison.CurrentCultureIgnoreCase)).Any";
-            }
+            var tagHelperReference = new CodeTypeReferenceExpression(typeof(TagHelper));
+            var scenarioTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), tagsOfScenarioVariableReferenceExpression);
+            var featureTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), featureFileTagFieldReferenceExpression);
 
-
-            var ifIsNullStatement = new CodeConditionStatement(CreateCheckForNullExpression(tagsOfScenarioVariableReferenceExpression), new CodeAssignStatement(isScenarioIgnoredVariableReferenceExpression,
-                new CodeMethodInvokeExpression(tagsOfScenarioVariableReferenceExpression, ignoreLinqStatement)));
-
-
-            var ifIsFeatureTagsNullStatement = new CodeConditionStatement(CreateCheckForNullExpression(featureFileTagFieldReferenceExpression), new CodeAssignStatement(isFeatureIgnoredVariableReferenceExpression,
-                new CodeMethodInvokeExpression(featureFileTagFieldReferenceExpression, ignoreLinqStatement)));
-
-
-            testMethod.Statements.Add(ifIsNullStatement);
-            testMethod.Statements.Add(ifIsFeatureTagsNullStatement);
-
-
-            var isScenarioOrFeatureIgnoredExpression = new CodeBinaryOperatorExpression(isScenarioIgnoredVariableReferenceExpression, CodeBinaryOperatorType.BooleanOr, isFeatureIgnoredVariableReferenceExpression);
-            var ifIsIgnoredStatement = new CodeConditionStatement(isScenarioOrFeatureIgnoredExpression, statementsWhenScenarioIsIgnored, statementsWhenScenarioIsExecuted.ToArray());
+            var ifIsIgnoredStatement = new CodeConditionStatement(
+                new CodeBinaryOperatorExpression(
+                    scenarioTagIgnoredCheckStatement,
+                    CodeBinaryOperatorType.BooleanOr,
+                    featureTagIgnoredCheckStatement),
+                statementsWhenScenarioIsIgnored,
+                statementsWhenScenarioIsExecuted.ToArray()
+                );
 
             testMethod.Statements.Add(ifIsIgnoredStatement);
         }
-
-        private static CodeBinaryOperatorExpression CreateCheckForNullExpression(CodeExpression variableReferenceExpression)
-        {
-            return new CodeBinaryOperatorExpression(variableReferenceExpression, CodeBinaryOperatorType.IdentityInequality, new CodePrimitiveExpression(null));
-        }
-
 
         internal void GenerateScenarioInitializeCall(TestClassGenerationContext generationContext, StepsContainer scenario, CodeMemberMethod testMethod)
         {
@@ -492,7 +469,7 @@ namespace TechTalk.SpecFlow.Generator.Generation
             string exampleSetIdentifier,
             bool rowTest = false)
         {
-            testMethod.Attributes = MemberAttributes.Public;
+            testMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             testMethod.Name = GetTestMethodName(scenarioDefinition, variantName, exampleSetIdentifier);
             var friendlyTestName = scenarioDefinition.Name;
             if (variantName != null)

--- a/TechTalk.SpecFlow/TagHelper.cs
+++ b/TechTalk.SpecFlow/TagHelper.cs
@@ -1,0 +1,31 @@
+﻿namespace TechTalk.SpecFlow
+{
+    #nullable enable
+    /// <summary>
+    /// Provides helper methods around tags.
+    /// </summary>
+    public static class TagHelper
+    {
+        /// <summary>
+        /// Checks whether the supplied tags contain the ignore tag
+        /// </summary>
+        /// <param name="tags">The tags to check.</param>
+        /// <returns>A boolean that indicates whether or not the ignore tag is present.</returns>
+        public static bool ContainsIgnoreTag(string[]? tags)
+        {
+            if (tags is null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < tags.Length; i++)
+            {
+                if (string.Equals(tags[i], "ignored", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Types of changes
Changes in a generated unit test (1. Image old, 2nd is new)
- featureTags to be static
![image](https://user-images.githubusercontent.com/2437596/116153136-25fe2180-a6e7-11eb-9dda-80580326e445.png)
![image](https://user-images.githubusercontent.com/2437596/116152662-79bc3b00-a6e6-11eb-9326-3fd89e82e141.png)

- in FeatureSetup to pass said featureTags directly instead of creating a new array
![image](https://user-images.githubusercontent.com/2437596/116153169-30202000-a6e7-11eb-901e-99580b039cb4.png)
![image](https://user-images.githubusercontent.com/2437596/116152608-6dd07900-a6e6-11eb-9cc7-341dbb5d95da.png)

- all instance methods to be non virtual
![image](https://user-images.githubusercontent.com/2437596/116153330-6d84ad80-a6e7-11eb-971d-f20142c1d9c7.png)
![image](https://user-images.githubusercontent.com/2437596/116152625-72952d00-a6e6-11eb-998a-b71a281d6638.png)

- to call TagHelper instead of individual LINQ
![image](https://user-images.githubusercontent.com/2437596/116153386-7ffee700-a6e7-11eb-92e3-a5ac5a59876c.png)
![image](https://user-images.githubusercontent.com/2437596/116152327-10d4c300-a6e6-11eb-902a-4bb2110d5cee.png)


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [x] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
