### PR TITLE
Auto update livingdoc reference major/minor in "dotnet new" template

### DIFF
--- a/Templates/TechTalk.SpecFlow.Templates.DotNet/templates/SpecFlowProject/Template.csproj
+++ b/Templates/TechTalk.SpecFlow.Templates.DotNet/templates/SpecFlowProject/Template.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-	<PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.7.10" />
+	<PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="$$$MajorMinorVersion$$$.*" />
     $SpecFlowNugetPackages$
     $additionalNugetPackages$
     $fluentAssertionsNugetPackage$

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Fixes:
++ Auto-update livingdoc major-minor in "dotnet new" template
+
 3.8
 
 Features:


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

The LivingDoc plugin reference needs to be in sync with the SpecFlow major/minor version.
The fix uses the major/minor of SpecFlow in the meta template to automatically keep in sync (similarly to the Runner reference).

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
