### PR TITLE
Fix xunit2 generator test for NonParallelizable collection attribute.

### DIFF
--- a/Tests/TechTalk.SpecFlow.GeneratorTests/UnitTestProvider/XUnit2TestGeneratorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/UnitTestProvider/XUnit2TestGeneratorProviderTests.cs
@@ -421,9 +421,10 @@ namespace TechTalk.SpecFlow.GeneratorTests.UnitTestProvider
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
-            attributes.Should()
-                .ContainSingle(a => a.Name == XUnitCollectionAttribute)
-                    .Which.Arguments.Should().BeEquivalentTo(new[] { new CodeAttributeArgument(new CodePrimitiveExpression("NonParallelizable")) });
+            attributes.Should().ContainSingle(a => a.Name == XUnitCollectionAttribute);
+            var collectionAttribute = attributes.Single(a => a.Name == XUnitCollectionAttribute);
+            collectionAttribute.Arguments.Should().HaveCount(1);
+            collectionAttribute.Arguments[0].Value.Should().BeEquivalentTo(new CodePrimitiveExpression("SpecFlowNonParallelizableFeatures"));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

Fixes a unit test that should have been failing, but wasn't.
I've verified that this unit test can fail :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
