### PR TITLE
Should not log error if TestAssembly does not have a RuntimePlugin attribute

### DIFF
--- a/TechTalk.SpecFlow/Infrastructure/ContainerBuilder.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContainerBuilder.cs
@@ -31,8 +31,6 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         public virtual IObjectContainer CreateGlobalContainer(Assembly testAssembly, IRuntimeConfigurationProvider configurationProvider = null)
         {
-            System.Diagnostics.Debugger.Launch();
-
             var container = new ObjectContainer();
             container.RegisterInstanceAs<IContainerBuilder>(this);
 

--- a/TechTalk.SpecFlow/Plugins/IRuntimePluginLoader.cs
+++ b/TechTalk.SpecFlow/Plugins/IRuntimePluginLoader.cs
@@ -6,6 +6,6 @@ namespace TechTalk.SpecFlow.Plugins
 {
     public interface IRuntimePluginLoader
     {
-        IRuntimePlugin LoadPlugin(string pluginAssemblyName, ITraceListener traceListener);
+        IRuntimePlugin LoadPlugin(string pluginAssemblyName, ITraceListener traceListener, bool traceMissingPluginAttribute);
     }
 }

--- a/TechTalk.SpecFlow/Plugins/RuntimePluginLoader.cs
+++ b/TechTalk.SpecFlow/Plugins/RuntimePluginLoader.cs
@@ -6,7 +6,7 @@ namespace TechTalk.SpecFlow.Plugins
 {
     public class RuntimePluginLoader : IRuntimePluginLoader
     {
-        public IRuntimePlugin LoadPlugin(string pluginAssemblyName, ITraceListener traceListener)
+        public IRuntimePlugin LoadPlugin(string pluginAssemblyName, ITraceListener traceListener, bool traceMissingPluginAttribute)
         {
             Assembly assembly;
             try
@@ -25,7 +25,9 @@ namespace TechTalk.SpecFlow.Plugins
             var pluginAttribute = (RuntimePluginAttribute)Attribute.GetCustomAttribute(assembly, typeof(RuntimePluginAttribute));
             if (pluginAttribute == null)
             {
-                traceListener.WriteToolOutput(string.Format("Missing [assembly:RuntimePlugin] attribute in {0}. Please check https://go.specflow.org/doc-plugins for details.", assembly.FullName));
+                if (traceMissingPluginAttribute)
+                    traceListener.WriteToolOutput(string.Format("Missing [assembly:RuntimePlugin] attribute in {0}. Please check https://go.specflow.org/doc-plugins for details.", assembly.FullName));
+
                 return null;
             }
 

--- a/Tests/TechTalk.SpecFlow.PluginTests/Infrastructure/WindsorPluginTests.cs
+++ b/Tests/TechTalk.SpecFlow.PluginTests/Infrastructure/WindsorPluginTests.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.PluginTests.Infrastructure
             var loader = new RuntimePluginLoader();
             var listener = new Mock<ITraceListener>();
 
-            var plugin = loader.LoadPlugin("SpecFlow.Windsor.SpecFlowPlugin.dll", listener.Object);
+            var plugin = loader.LoadPlugin("SpecFlow.Windsor.SpecFlowPlugin.dll", listener.Object, It.IsAny<bool>());
 
             plugin.Should().NotBeNull();
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/PluginTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/PluginTests.cs
@@ -313,7 +313,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
 
             var pluginLoaderStub = new Mock<IRuntimePluginLoader>();
             var traceListener = container.Resolve<ITraceListener>();
-            pluginLoaderStub.Setup(pl => pl.LoadPlugin(It.IsAny<string>(), traceListener)).Returns(_pluginToReturn);
+            pluginLoaderStub.Setup(pl => pl.LoadPlugin(It.IsAny<string>(), traceListener, It.IsAny<bool>())).Returns(_pluginToReturn);
 
 
             container.RegisterInstanceAs<IRuntimePluginLocator>(runtimePluginLocator.Object);

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Changes:
 Fixes:
 + Fix Type or namespace [TestNamespace]_XunitAssemblyFixture could not be found #1825
 + Fix Default value deserialization from specflow.json #2239 #2439
++ Should not log error if TestAssembly does not have a RuntimePlugin attribute #2432
 
 
 3.8


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

Fixes #2432 

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
