### PR TITLE
Make the ignored tests to be decorated with the Ignore category as well

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestConverter/IgnoreDecorator.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestConverter/IgnoreDecorator.cs
@@ -40,6 +40,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestConverter
         public void DecorateFrom(string tagName, TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
         {
             generationContext.UnitTestGeneratorProvider.SetTestMethodIgnore(generationContext, testMethod);
+            generationContext.UnitTestGeneratorProvider.SetTestMethodCategories(generationContext, testMethod, new[] { IGNORE_TAG });
         }
 
         public bool CanDecorateFrom(string tagName, TestClassGenerationContext generationContext)
@@ -50,6 +51,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestConverter
         public void DecorateFrom(string tagName, TestClassGenerationContext generationContext)
         {
             generationContext.UnitTestGeneratorProvider.SetTestClassIgnore(generationContext);
+            generationContext.UnitTestGeneratorProvider.SetTestClassCategories(generationContext, new[] { IGNORE_TAG });
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+3.10.1
+
+Changes:
++ Make the ignored tests to be decorated with the Ignore category as well.
+
 3.10
 
 Changes:


### PR DESCRIPTION
The goal here is to make the ignored tests to be decorated with the Ignore category as well as it is decorated appropriately for each test framework. This allows to set up freely the test filter for each runner. The issue is that the ignored tests are inadequately factored in the math of tests pass percentage, which makes them included in/as the not-passed factor. Microsoft is not going to change this behavior in the classic release pipelines so that is a must-have workaround in order to achieve the proper statistics of the BDD tests.

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
