### PR TITLE
Fix typo in Value Retrievers doc: change Registr to Register

### DIFF
--- a/docs/Extend/Value-Retriever.md
+++ b/docs/Extend/Value-Retriever.md
@@ -86,7 +86,7 @@ public class ShirtColorValueRetriever : IValueRetriever
 
 ## Registering Custom ValueRetrievers
 
-Before you can utilize a custom `ValueRetriever`, you'll need to register it. We recommend doing this prior to a test run using the `[BeforeTestRun]` attribute and `Service.Instance.ValueRetrievers.Registr()`. For example:
+Before you can utilize a custom `ValueRetriever`, you'll need to register it. We recommend doing this prior to a test run using the `[BeforeTestRun]` attribute and `Service.Instance.ValueRetrievers.Register()`. For example:
 
 ``` csharp
 [Binding]


### PR DESCRIPTION
Fixed a typo in the Value Retrievers documentation page. Changed Registr to Register.
Fixes issue #2544

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [X] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
