### PR TITLE
Make XUnit2TestGeneratorProvider.SetTestMethod virtual

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -262,7 +262,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                     generationContext.TestClassCleanupMethod.Name));
         }
 
-        public void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
+        public virtual void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
         {
             CodeDomHelper.AddAttribute(testMethod, FACT_ATTRIBUTE, new CodeAttributeArgument("DisplayName", new CodePrimitiveExpression(friendlyTestName)));
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 Changes:
 + Remove Cucumber- Messages
++ Made XUnit2TestGeneratorProvider.SetTestMethod virtual so that it can be replaced by generator plugins
 
 3.9
 


### PR DESCRIPTION
Make XUnit2TestGeneratorProvider.SetTestMethod virtual so that it can be replaced by generator plugins.
I needed to make this change for a new feature in my generator plugin, src using it here: https://github.com/JoshKeegan/xRetry/blob/5494809b736bc50c8bcdf24ece71b6623a2f6d4c/src/xRetry.SpecFlow/TestGeneratorProvider.cs#L35

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
