### PR TITLE
add DateTimeStyles to DateTime(Offset)ValueRetriever

### DIFF
--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -5,9 +5,15 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class DateTimeOffsetValueRetriever : StructRetriever<DateTimeOffset>
     {
+        /// <summary>
+        /// Gets or sets the DateTimeStyles to use when parsing the string value.
+        /// </summary>
+        /// <remarks>Defaults to DateTimeStyles.None.</remarks>
+        public static DateTimeStyles DateTimeStyles { get; set; } = DateTimeStyles.None;
+
         protected override DateTimeOffset GetNonEmptyValue(string value)
         {
-            DateTimeOffset.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles.None, out DateTimeOffset returnValue);
+            DateTimeOffset.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles, out DateTimeOffset returnValue);
             return returnValue;
         }
     }

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeValueRetriever.cs
@@ -5,9 +5,15 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class DateTimeValueRetriever : StructRetriever<DateTime>
     {
+        /// <summary>
+        /// Gets or sets the DateTimeStyles to use when parsing the string value.
+        /// </summary>
+        /// <remarks>Defaults to DateTimeStyles.None.</remarks>
+        public static DateTimeStyles DateTimeStyles { get; set; } = DateTimeStyles.None;
+
         protected override DateTime GetNonEmptyValue(string value)
         {
-            DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles.None, out DateTime returnValue);
+            DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles, out DateTime returnValue);
             return returnValue;
         }
     }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     {
         private const string IrrelevantKey = "Irrelevant";
         private readonly Type IrrelevantType = typeof(object);
-        
+
         public DateTimeOffsetValueRetrieverTests()
         {
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
@@ -112,6 +112,25 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             Retrieve_correct_nullable_value("Thursday", DateTimeOffset.MinValue);
             Retrieve_correct_value("Friday too", DateTimeOffset.MinValue);
             Retrieve_correct_nullable_value("Friday too", DateTimeOffset.MinValue);
+        }
+
+        [Fact]
+        public void Uses_provided_styles()
+        {
+            var oldStyle = DateTimeOffsetValueRetriever.DateTimeStyles;
+            try
+            {
+                DateTimeOffsetValueRetriever.DateTimeStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal;
+
+                Retrieve_correct_value("1/1/2011 15:16:17", new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZoneInfo.Utc.BaseUtcOffset));
+                Retrieve_correct_nullable_value("1/1/2011 15:16:17", new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZoneInfo.Utc.BaseUtcOffset));
+                Retrieve_correct_value("1/1/2011 5:6:7", new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZoneInfo.Utc.BaseUtcOffset));
+                Retrieve_correct_nullable_value("1/1/2011 5:6:7", new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZoneInfo.Utc.BaseUtcOffset));
+            }
+            finally
+            {
+                DateTimeOffsetValueRetriever.DateTimeStyles = oldStyle;
+            }
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeValueRetrieverTests.cs
@@ -34,6 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             var retriever = new DateTimeValueRetriever();
             var result = (DateTime)retriever.Retrieve(new KeyValuePair<string, string>(IrrelevantKey, value), IrrelevantType, typeof(DateTime));
             result.Should().Be(expectation);
+            result.Kind.Should().Be(expectation.Kind);
         }
 
         private void Retrieve_correct_nullable_value(string value, DateTime? expectation)
@@ -105,6 +106,25 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             Retrieve_correct_nullable_value("this is not a date", DateTime.MinValue);
             Retrieve_correct_value("Thursday", DateTime.MinValue);
             Retrieve_correct_nullable_value("Thursday", DateTime.MinValue);
+        }
+
+        [Fact]
+        public void Uses_provided_styles()
+        {
+            var oldStyle = DateTimeValueRetriever.DateTimeStyles;
+            try
+            {
+                DateTimeValueRetriever.DateTimeStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal;
+
+                Retrieve_correct_value("1/1/2011 15:16:17", new DateTime(2011, 1, 1, 15, 16, 17, DateTimeKind.Utc));
+                Retrieve_correct_nullable_value("1/1/2011 15:16:17", new DateTime(2011, 1, 1, 15, 16, 17, DateTimeKind.Utc));
+                Retrieve_correct_value("1/1/2011 5:6:7", new DateTime(2011, 1, 1, 5, 6, 7, DateTimeKind.Utc));
+                Retrieve_correct_nullable_value("1/1/2011 5:6:7", new DateTime(2011, 1, 1, 5, 6, 7, DateTimeKind.Utc));
+            }
+            finally
+            {
+                DateTimeValueRetriever.DateTimeStyles = oldStyle;
+            }
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 Changes:
 + improve Service.GetValueRetrieverFor performance
++ Add DateTimeStyles to DateTimeValueRetriever and DateTimeOffsetValueRetriever
 
 3.9.40
 

--- a/docs/Bindings/SpecFlow-Assist-Helpers.md
+++ b/docs/Bindings/SpecFlow-Assist-Helpers.md
@@ -265,6 +265,24 @@ Examples on implementing these interfaces can be found as follows:
 * [IValueRetriever](https://github.com/techtalk/SpecFlow/tree/v2/Runtime/Assist/ValueRetrievers)
 * [IValueComparer](https://github.com/techtalk/SpecFlow/tree/v2/Runtime/Assist/ValueComparers)
 
+### Configuration
+
+Some built in classes support configuration to adjust the default behaviour.
+- [DateTimeValueRetriever](../../TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeValueRetriever.cs) and [DateTimeOffsetValueRetriever](../../TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs) have a static DateTimeStyles property to adjust the style used to parse date times.
+
+Example of usage:
+``` csharp
+[Binding]
+public static class Hooks1
+{
+    [BeforeTestRun]
+    public static void BeforeTestRun()
+    {
+        DateTimeValueRetriever.DateTimeStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal;
+    }
+}
+```
+
 ### NullValueRetriever (from SpecFlow 3)
 
 By default, non-specified (empty string) values are considered:


### PR DESCRIPTION
This change adds a way to modify the DateTimeStyles used when parsing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:
- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
