### PR TITLE
Changed NUnit3TestGeneratorProvider.SetTestMethod() and NUnit3TestGeneratorProvider.SetRowTest() to virtual

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
@@ -98,7 +98,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(generationContext.TestCleanupMethod, TESTTEARDOWN_ATTR);
         }
 
-        public void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
+        public virtual void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
         {
             CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
             CodeDomHelper.AddAttribute(testMethod, DESCRIPTION_ATTR, friendlyTestName);
@@ -109,7 +109,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             CodeDomHelper.AddAttributeForEachValue(testMethod, CATEGORY_ATTR, scenarioCategories);
         }
 
-        public void SetRowTest(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle)
+        public virtual void SetRowTest(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle)
         {
             SetTestMethod(generationContext, testMethod, scenarioTitle);
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 Changes:
 + improve Service.GetValueRetrieverFor performance
++ Update NUnit3TestGeneratorProvider - SetTestMethod and SetRowTest are now virtual so that it can be replaced by generator plugins
 
 3.9.40
 


### PR DESCRIPTION
Changed NUnit3TestGeneratorProvider.SetTestMethod() and NUnit3TestGeneratorProvider.SetRowTest() to virtual. This will enable them to be overriden in generator plugins.

**Why?**
XUnit2TestGeneratorProvider has these methods virtual. This enables overriding but keeping the ability to invoke base methods' code. 
This enables generator plugin devs to add additional functionality such as adding custom attributes during tag discovery in various situations (scenarios/scenario outlines/features/with tag/without tag). 

NUnit3TestGeneratorProvider hasn't these methods virtual. Therefore, anyone who would want to override functionality, had to copy the entire NUnit3TestGeneratorProvider's body, and then add desired additional functionality. This could cause 3rd party generator plugins to be prone to updates in NUnit3TestGeneratorProvider class. 


<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
