### PR TITLE
adjusted duration output to milliseconds

### DIFF
--- a/TechTalk.SpecFlow/Tracing/TestTracer.cs
+++ b/TechTalk.SpecFlow/Tracing/TestTracer.cs
@@ -26,6 +26,8 @@ namespace TechTalk.SpecFlow.Tracing
 
     public class TestTracer : ITestTracer
     {
+        private static readonly TimeSpan MillisecondsThreshold = TimeSpan.FromMilliseconds(300);
+
         private readonly ITraceListener traceListener;
         private readonly IStepFormatter stepFormatter;
         private readonly IStepDefinitionSkeletonProvider stepDefinitionSkeletonProvider;
@@ -130,13 +132,27 @@ namespace TechTalk.SpecFlow.Tracing
 
         public void TraceDuration(TimeSpan elapsed, IBindingMethod method, object[] arguments)
         {
-            traceListener.WriteToolOutput("duration: {0}: {1:F1}s",
-                stepFormatter.GetMatchText(method, arguments), elapsed.TotalSeconds);
+            string matchText = stepFormatter.GetMatchText(method, arguments);
+            if (elapsed > MillisecondsThreshold)
+            {
+                traceListener.WriteToolOutput($"duration: {matchText}: {elapsed.TotalSeconds:F1}s");
+            }
+            else
+            {
+                traceListener.WriteToolOutput($"duration: {matchText}: {elapsed.TotalMilliseconds:F1}ms");
+            }
         }
 
         public void TraceDuration(TimeSpan elapsed, string text)
         {
-            traceListener.WriteToolOutput("duration: {0}: {1:F1}s", text, elapsed.TotalSeconds);
+            if (elapsed > MillisecondsThreshold)
+            {
+                traceListener.WriteToolOutput($"duration: {text}: {elapsed.TotalSeconds:F1}s");
+            }
+            else
+            {
+                traceListener.WriteToolOutput($"duration: {text}: {elapsed.TotalMilliseconds:F1}ms");
+            }
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+3.9.58
+
+Changes:
++ adjust the duration output to milliseconds if it's below 300ms threshold
+
 3.9.52
 
 Changes:


### PR DESCRIPTION
The intent of this change is to modify the output of the duration string to milliseconds if it's below a certain threshold.
(This is useful when the steps you execute are in the milliseconds range, so outputting 0.1s isn't particularly useful)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
