### PR TITLE
Update rules for step definitions methods

### DIFF
--- a/docs/Bindings/Step-Definitions.md
+++ b/docs/Bindings/Step-Definitions.md
@@ -66,7 +66,7 @@ The `[Obsolete]` attribute from the system namespace is also supported, check [h
 * Must be a public method.
 * Can be either a static or an instance method. If it is an instance method, the containing class will be instantiated once for every scenario.
 * Cannot have `out` or `ref` parameters.
-* Cannot have a return type or have `Task` as return type.
+* Shouldn't have a return type or have `Task` as return type.
 
 ## Step Matching Styles & Rules
 


### PR DESCRIPTION
The Step Definition Methods Rules section states that "method can not have a return type or have a `Task` as return type". I tried to change my method to return `int` instead of `void` and it works without errors. So I guess if it's not a rule which would cause an error than it should be rather recommendation than rule.

If it's a bug that SpecFlow should catch, I can provide you steps to reproduce it (although it's a very simple 😀)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [X] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
