### PR TITLE
Support IReadOnlyCollection binding for ListValueRetriever

### DIFF
--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/ListValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/ListValueRetriever.cs
@@ -22,7 +22,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
                    || genericType == typeof(IEnumerable<>)
                    || genericType == typeof(ICollection<>)
                    || genericType == typeof(IList<>)
-                   || genericType == typeof(IReadOnlyList<>);
+                   || genericType == typeof(IReadOnlyList<>)
+                   || genericType == typeof(IReadOnlyCollection<>);
         }
 
         protected override Type GetActualValueType(Type propertyType)

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ListRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ListRetrieverTests.cs
@@ -21,6 +21,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
                 typeof(IList<>),
                 typeof(List<>),
                 typeof(IReadOnlyList<>),
+                typeof(IReadOnlyCollection<>),
             };
             
             return propertyTypeDefinitions.Select(x => x.MakeGenericType(valueType));


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->
The intent of this change is to support IReadOnlyCollection binding for ListValueRetriever #2497. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
