### PR TITLE
Move interface ISpecFlowOutputHelper to the TechTalk.SpecFlow namespace

### DIFF
--- a/TechTalk.SpecFlow/ISpecFlowOutputHelper.cs
+++ b/TechTalk.SpecFlow/ISpecFlowOutputHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace TechTalk.SpecFlow.Infrastructure
+﻿namespace TechTalk.SpecFlow
 {
     public interface ISpecFlowOutputHelper
     {

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/ContextInjection.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Contexts/ContextInjection.feature
@@ -37,7 +37,7 @@ Background:
 		{
 			private object _lock = new object();
 
-			public DisposableContext(TechTalk.SpecFlow.Infrastructure.ISpecFlowOutputHelper outputHelper)
+			public DisposableContext(ISpecFlowOutputHelper outputHelper)
 			{
 				outputHelper.WriteLine("DisposableContext");
 			}

--- a/Tests/TechTalk.SpecFlow.Specs/Support/OutputConnector.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Support/OutputConnector.cs
@@ -1,5 +1,4 @@
-﻿using TechTalk.SpecFlow.Infrastructure;
-using TechTalk.SpecFlow.TestProjectGenerator;
+﻿using TechTalk.SpecFlow.TestProjectGenerator;
 
 namespace TechTalk.SpecFlow.Specs.Support
 {

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,9 @@
 Features:
 + Add an option to colorize test result output
 
+Changes:
++ The interface ISpecFlowOutputHelper has been moved to the TechTalk.SpecFlow namespace (from TechTalk.SpecFlow.Infrastructure).
+
 3.10
 
 Features:


### PR DESCRIPTION
It was in namespace `TechTalk.SpecFlow.Infrastructure` that is an internal namespace and not suppose to be needed for regular end users. Technically it is a breaking change, but users of `ISpecFlowOutputHelper` surely had the `TechTalk.SpecFlow` namespace, e.g. for the `[Given/When/Then]` attributes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
