### PR TITLE
Allow Autofac plugin to provide existing lifetime scope

### DIFF
--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
@@ -80,7 +80,13 @@ namespace SpecFlow.Autofac
                         return featureScope.BeginLifetimeScope(nameof(ScenarioContext), containerBuilder =>
                         {
                             var configureScenarioContainer = containerBuilderFinder.GetConfigureScenarioContainer();
-                            RegisterSpecflowDependecies(args.ObjectContainer, configureScenarioContainer(containerBuilder));
+
+                            if (configureScenarioContainer != null)
+                            {
+                                containerBuilder = configureScenarioContainer(containerBuilder);
+                            }
+
+                            RegisterSpecflowDependecies(args.ObjectContainer, containerBuilder);
                         });
                     }
 
@@ -97,12 +103,20 @@ namespace SpecFlow.Autofac
                 });
             };
         }
+
         private static ILifetimeScope GetFeatureScope(ObjectContainer objectContainer, IContainerBuilderFinder containerBuilderFinder)
         {
             var configureScenarioContainer = containerBuilderFinder.GetConfigureScenarioContainer();
             if (objectContainer.BaseContainer.IsRegistered<ILifetimeScope>() && configureScenarioContainer != null)
             {
                 return objectContainer.BaseContainer.Resolve<ILifetimeScope>();
+            }
+
+            var lifetimeScope = containerBuilderFinder.GetLifetimeScope();
+
+            if (lifetimeScope != null)
+            {
+                return lifetimeScope();
             }
 
             if (configureScenarioContainer != null)

--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
@@ -72,12 +72,14 @@ namespace SpecFlow.Autofac
                 }
                 else if (args.ObjectContainer.BaseContainer.IsRegistered<ILifetimeScope>())
                 {
-                    featureScope = args.ObjectContainer.BaseContainer.Resolve<ILifetimeScope>();
+                    var testThreadScope = args.ObjectContainer.BaseContainer.Resolve<ILifetimeScope>();
+
+                    featureScope = testThreadScope.BeginLifetimeScope(nameof(FeatureContext));
                 }
 
                 if (featureScope != null)
                 {
-                    args.ObjectContainer.RegisterFactoryAs(() => featureScope.BeginLifetimeScope(nameof(FeatureContext)));
+                    args.ObjectContainer.RegisterInstanceAs(featureScope);
                 }
             };
 

--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacTestObjectResolver.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/AutofacTestObjectResolver.cs
@@ -20,6 +20,7 @@ namespace SpecFlow.Autofac
                 var lifeTimeScope = container.Resolve<ILifetimeScope>();
                 return lifeTimeScope.Resolve(bindingType);
             }
+
             return container.Resolve(bindingType);
         }
     }

--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/ContainerBuilderFinder.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/ContainerBuilderFinder.cs
@@ -10,7 +10,6 @@ using ContainerBuilder = Autofac.ContainerBuilder;
 
 namespace SpecFlow.Autofac
 {
-
     public class ContainerBuilderFinder : IContainerBuilderFinder
     {
         private readonly IBindingRegistry bindingRegistry;
@@ -19,7 +18,7 @@ namespace SpecFlow.Autofac
         private readonly Lazy<Func<ContainerBuilder, ContainerBuilder>> createConfigureGlobalContainer;
         private readonly Lazy<Func<ContainerBuilder, ContainerBuilder>> createConfigureScenarioContainer;
         private readonly Lazy<Func<ContainerBuilder, ContainerBuilder>> createScenarioContainerBuilder;
-        private readonly Lazy<Func<ILifetimeScope>> getLifetimeScope;
+        private readonly Lazy<Func<ILifetimeScope>> getFeatureLifetimeScope;
 
         public ContainerBuilderFinder(IBindingRegistry bindingRegistry, IRuntimeBindingRegistryBuilder bindingRegistryBuilder, ITestAssemblyProvider testAssemblyProvider)
         {
@@ -34,7 +33,7 @@ namespace SpecFlow.Autofac
             createConfigureGlobalContainer = new Lazy<Func<ContainerBuilder, ContainerBuilder>>(() => FindCreateScenarioContainerBuilder(typeof(GlobalDependenciesAttribute), typeof(void), invokeVoidAndReturnBuilder), true);
             createConfigureScenarioContainer = new Lazy<Func<ContainerBuilder, ContainerBuilder>>(() => FindCreateScenarioContainerBuilder(typeof(ScenarioDependenciesAttribute), typeof(void), invokeVoidAndReturnBuilder), true);
             createScenarioContainerBuilder = new Lazy<Func<ContainerBuilder, ContainerBuilder>>(() => FindCreateScenarioContainerBuilder(typeof(ScenarioDependenciesAttribute), typeof(ContainerBuilder), (c, m) => (ContainerBuilder)m.Invoke(null, null)), true);
-            getLifetimeScope = new Lazy<Func<ILifetimeScope>>(() => FindLifetimeScope(typeof(ScenarioDependenciesAttribute), typeof(ILifetimeScope), m => (ILifetimeScope)m.Invoke(null, null)));
+            getFeatureLifetimeScope = new Lazy<Func<ILifetimeScope>>(() => FindLifetimeScope(typeof(FeatureDependenciesAttribute), typeof(ILifetimeScope), m => (ILifetimeScope)m.Invoke(null, null)));
         }
 
         public Func<ContainerBuilder, ContainerBuilder> GetConfigureGlobalContainer()
@@ -53,9 +52,9 @@ namespace SpecFlow.Autofac
             return createScenarioContainerBuilder.Value;
         }
 
-        public Func<ILifetimeScope> GetLifetimeScope()
+        public Func<ILifetimeScope> GetFeatureLifetimeScope()
         {
-            return getLifetimeScope.Value;
+            return getFeatureLifetimeScope.Value;
         }
 
         protected virtual Func<ILifetimeScope> FindLifetimeScope(Type attributeType, Type returnType, Func<MethodInfo, ILifetimeScope> invoke)

--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/FeatureDependenciesAttribute.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/FeatureDependenciesAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SpecFlow.Autofac
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class FeatureDependenciesAttribute : Attribute
+    {
+    }
+}

--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/IContainerBuilderFinder.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/IContainerBuilderFinder.cs
@@ -10,5 +10,7 @@ namespace SpecFlow.Autofac
         Func<ContainerBuilder, ContainerBuilder> GetConfigureGlobalContainer();
 
         Func<ContainerBuilder, ContainerBuilder> GetCreateScenarioContainerBuilder();
+
+        Func<ILifetimeScope> GetLifetimeScope();
     }
 }

--- a/Plugins/SpecFlow.Autofac.SpecFlowPlugin/IContainerBuilderFinder.cs
+++ b/Plugins/SpecFlow.Autofac.SpecFlowPlugin/IContainerBuilderFinder.cs
@@ -11,6 +11,6 @@ namespace SpecFlow.Autofac
 
         Func<ContainerBuilder, ContainerBuilder> GetCreateScenarioContainerBuilder();
 
-        Func<ILifetimeScope> GetLifetimeScope();
+        Func<ILifetimeScope> GetFeatureLifetimeScope();
     }
 }

--- a/docs/Integrations/Autofac.md
+++ b/docs/Integrations/Autofac.md
@@ -91,4 +91,27 @@ public static void CreateContainerBuilder(ContainerBuilder containerBuilder)
   (Recommended to put it into the `Support` folder) that returns an Autofac `ContainerBuilder` and tag it with the `[ScenarioDependencies]` attribute. 
 
 
+  ### 5. If you have an existing container, built and owned by your application under test, you can use that instead of letting SpecFlow manage your container
+  Create a static method in your SpecFlow project to return a lifetime scope from your container. Note that SpecFlow creates a second scope under yours, 
+  so be sure to pair this use-case with the `CreateContainerBuilder` method above to add your step bindings.
+
+```csharp
+[ScenarioDependencies]
+public static ILifetimeScope GetLifetimeScope()
+{
+    // TODO: Add any top-level dependencies here, though note that usually step bindings
+	//       should be declared in the Configure method below, as this will ensure they
+	//       are in the correct scope to inject ScenarioContext etc.
+    return containerScope.BeginLifetimeScope();
+}
+
+[ScenarioDependencies]
+public static void ConfigureContainerBuilder(ContainerBuilder containerBuilder)
+{
+    //TODO: add customizations, stubs required for testing
+
+    containerBuilder.AddSpecFlowBindings<TestDependencies>();
+    containerBuilder.AddSpecFlowBindings<TestDependencies>();
+}
+```
 

--- a/docs/Integrations/Autofac.md
+++ b/docs/Integrations/Autofac.md
@@ -96,8 +96,8 @@ public static void CreateContainerBuilder(ContainerBuilder containerBuilder)
   so be sure to pair this use-case with the `CreateContainerBuilder` method above to add your step bindings.
 
 ```csharp
-[ScenarioDependencies]
-public static ILifetimeScope GetLifetimeScope()
+[FeatureDependencies]
+public static ILifetimeScope GetFeatureLifetimeScope()
 {
     // TODO: Add any top-level dependencies here, though note that usually step bindings
 	//       should be declared in the Configure method below, as this will ensure they
@@ -110,7 +110,6 @@ public static void ConfigureContainerBuilder(ContainerBuilder containerBuilder)
 {
     //TODO: add customizations, stubs required for testing
 
-    containerBuilder.AddSpecFlowBindings<TestDependencies>();
     containerBuilder.AddSpecFlowBindings<TestDependencies>();
 }
 ```


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->
The use case for this change is when running a specflow test suite that tests an ASP.NET Core application using Autofac internally.  Specflow should be able to use all the existing registrations in the application container, and then be able to override specific registrations (for proxying services), register the bindings, and contexts.

Let me know your thoughts, thanks!

For example:

```c#
// Top-level Program.cs
var builder = WebApplication.CreateBuilder(args);
builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());
builder.Host.ConfigureContainer<ContainerBuilder>(x =>
{
    // TODO: Add types and modules
});

var app = builder.Build();

app.MapGet("/weatherforecast", () => new object());

app.Run();
```

```c#
// SpecFlow scaffolding handling app startup/shutdown
[Binding]
public class Hooks
{
    private static ILifetimeScope container;

    [ScenarioDependencies]
    public static ILifetimeScope GetLifetimeScope()
    {
        return container.BeginLifetimeScope();
    }

    [ScenarioDependencies]
    public static void ConfigureScenarioContainer(ContainerBuilder builder)
    {
        builder.AddSpecFlowBindings<Hooks>();
    }

    [BeforeTestRun]
    public static void OnStart()
    {
        var application = new IntegrationApplication();
        var client = application.CreateClient();

        container = application.Services.GetRequiredService<ILifetimeScope>();
    }

    private class IntegrationApplication : WebApplicationFactory<Program>
    {
        protected override IHost CreateHost(IHostBuilder builder)
        {
            builder.ConfigureContainer<ContainerBuilder>(x =>
            {
                //TODO: Register modules and types for test run
            });

            return base.CreateHost(builder);
        }
    }
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
