### PR TITLE
Made scenario and feature context items more thread-safe

### DIFF
--- a/TechTalk.SpecFlow/SpecFlowContext.cs
+++ b/TechTalk.SpecFlow/SpecFlowContext.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace TechTalk.SpecFlow
 {
@@ -8,7 +8,7 @@ namespace TechTalk.SpecFlow
         Exception TestError { get; }
     }
 
-    public abstract class SpecFlowContext : Dictionary<string, object>, IDisposable
+    public abstract class SpecFlowContext : ConcurrentDictionary<string, object>, IDisposable
     {
         public Exception TestError { get; internal set; }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/SpecFlowContextThreadSafetyTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/SpecFlowContextThreadSafetyTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BoDi;
+using Moq;
+using TechTalk.SpecFlow.Infrastructure;
+using TechTalk.SpecFlow.Tracing;
+using Xunit;
+
+namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
+{
+    /// <summary>
+    ///     Test class which verifies that the <see cref="ScenarioContext"/> and <see cref="FeatureContext"/> Dictionary is thread-safe.
+    /// </summary>
+    public class SpecFlowContextThreadSafetyTests : StepExecutionTestsBase
+    {
+        private ContextManager CreateContextManager(IObjectContainer testThreadContainer)
+        {
+            return new ContextManager(new Mock<ITestTracer>().Object, testThreadContainer, ContainerBuilderStub);
+        }
+
+        [Fact]
+        public void Test_Scenario_Context_Thread_Safety()
+        {
+            var containerBuilder = new RuntimeTestsContainerBuilder();
+            var testThreadContainer = containerBuilder.CreateTestThreadContainer(containerBuilder.CreateGlobalContainer(typeof(SpecFlowContextThreadSafetyTests).Assembly));
+            var contextManager = CreateContextManager(testThreadContainer);
+            contextManager.InitializeFeatureContext(new FeatureInfo(FeatureLanguage, "", "test feature", null));
+            contextManager.InitializeScenarioContext(new ScenarioInfo("test scenario", "test_description", null, null));
+
+            // setup a list containing unique numbers.
+            var taskNumbers = new List<int>();
+            while (taskNumbers.Count < 100) taskNumbers.Add(taskNumbers.Count + 1);
+
+            // run a task for each number in the list which sets the ScenarioContext item to this unique number in parallel
+            Parallel.ForEach(
+                taskNumbers, (i) =>
+                {
+                    contextManager.ScenarioContext[$"key_{i}"] = i;
+                });
+            
+            // Verify that all of the ScenarioContext items has their expected value. 
+            // This fails with different kind of errors when SpecFlowContext inherits from Dictionary in stead of ConcurrentDictionary.
+            Assert.All(taskNumbers, (i) =>
+            {
+                var contextItem = (int) contextManager.ScenarioContext[$"key_{i}"]; 
+                Assert.Equal(contextItem , i);
+            });
+        }
+        
+        [Fact]
+        public void Test_Feature_Context_Thread_Safety()
+        {
+            var containerBuilder = new RuntimeTestsContainerBuilder();
+            var testThreadContainer = containerBuilder.CreateTestThreadContainer(containerBuilder.CreateGlobalContainer(typeof(SpecFlowContextThreadSafetyTests).Assembly));
+            var contextManager = CreateContextManager(testThreadContainer);
+            contextManager.InitializeFeatureContext(new FeatureInfo(FeatureLanguage, "", "test feature", null));
+            contextManager.InitializeScenarioContext(new ScenarioInfo("test scenario", "test_description", null, null));
+
+            // setup a list containing unique numbers.
+            var taskNumbers = new List<int>();
+            while (taskNumbers.Count < 100) taskNumbers.Add(taskNumbers.Count + 1);
+
+            // run a task for each number in the list which sets the FeatureContext item to this unique number in parallel
+            Parallel.ForEach(
+                taskNumbers, (i) =>
+                {
+                    contextManager.FeatureContext[$"key_{i}"] = i;
+                });
+            
+            // Verify that all of the FeatureContext items has their expected value. 
+            // This fails with different kind of errors when SpecFlowContext inherits from Dictionary in stead of ConcurrentDictionary.
+            Assert.All(taskNumbers, (i) =>
+            {
+                var contextItem = (int) contextManager.FeatureContext[$"key_{i}"]; 
+                Assert.Equal(contextItem , i);
+            });
+        }
+    }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Changes:
 + Default step definition skeletons are generating cucumber expressions.
 + 'ScenarioInfo.ScenarioAndFeatureTags' has been deprecated in favor of 'ScenarioInfo.CombinedTags'. Now both contain rule tags as well.
 + The interface ISpecFlowOutputHelper has been moved to the TechTalk.SpecFlow namespace (from TechTalk.SpecFlow.Infrastructure).
++ The Dictionary behind ScenarioContext, FeatureContext and ScenarioStepContext to store custom data in is now thread-safe
 
 3.10
 


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

The `Dictionary` behind the `ScenarioContext` and `FeatureContext` is not thread-safe. Different kind of errors can occur if tests are executed with parallel access to the ScenarioContext/FeatureContext `Dictionary`. I've added a sample unit test which fails in case of using a default `Dictionary` in stead of a `ConcurrentDictionary` to demonstrate this. I think some open issues can be related to this.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
