### PR TITLE
#2608: Await the call to FeatureBackgroundAsync

### DIFF
--- a/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Generation/UnitTestMethodGenerator.cs
@@ -256,10 +256,12 @@ namespace TechTalk.SpecFlow.Generator.Generation
             {
                 using (new SourceLineScope(_specFlowConfiguration, _codeDomHelper, statementsWhenScenarioIsExecuted, generationContext.Document.SourceFilePath, generationContext.Feature.Background.Location))
                 {
-                    statementsWhenScenarioIsExecuted.Add(new CodeExpressionStatement(
-                        new CodeMethodInvokeExpression(
-                            new CodeThisReferenceExpression(),
-                            generationContext.FeatureBackgroundMethod.Name)));
+                    var backgroundMethodCallExpression = new CodeMethodInvokeExpression(
+                        new CodeThisReferenceExpression(),
+                        generationContext.FeatureBackgroundMethod.Name);
+
+                    _codeDomHelper.MarkCodeMethodInvokeExpressionAsAwait(backgroundMethodCallExpression);
+                    statementsWhenScenarioIsExecuted.Add(new CodeExpressionStatement(backgroundMethodCallExpression));
                 }
             }
 


### PR DESCRIPTION
Ensure that calls to `FeatureBackgroundAsync` are awaited when called, i.e. 

Instead of this

```csharp
// ... snip ...
#line 4
    this.FeatureBackgroundAsync();
#line hidden
// ... snip ...
```

Generate this
```csharp
// ... snip ...
#line 4
    await this.FeatureBackgroundAsync();
#line hidden
// ... snip ...
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

--- 
Note: I've not added tests or an entry to the change log for the following reasons:
- There are no existing tests for the UnitTestMethodGenerator; if you require them then i can have a look to create some
- I've not added an entry to the changelog as this fixes a change within the 4.0.16-beta version, as such it fixes an issue during the beta. Once again if this is required, please let me know and i'll add something in.