### PR TITLE
Fix link in readme to FAQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SpecFlow is a pragmatic BDD solution for .NET. It provides test automation for .
 - Project website: [https://www.specflow.org](https://www.specflow.org)
 - [Documentation](https://specflow.org/documentation/)
 - [Getting Started](https://specflow.org/getting-started/)
-- [FAQ](https://specflow.org/documentation/FAQ/)
+- [FAQ](https://docs.specflow.org/en/latest/faqs.html)
 - [BDD](https://specflow.org/learn/bdd/)
 - [Given-When-Then](https://specflow.org/learn/given-when-then-with-style/)
 - [SpecFlow on GitHub](https://github.com/SpecFlowOSS/SpecFlow)


### PR DESCRIPTION
Hello 👋🏽 

I just wanted to check the faq's to read something about known performance advices, but realized that the link leads to a 404.
I discovered the new link to the faq's by myself, so i hope it is the right one.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)
