### PR TITLE
Fix #2600 by preserving ExecutionContext and reuse it for subsequent binding method invocations

### DIFF
--- a/TechTalk.SpecFlow/Bindings/AsyncMethodHelper.cs
+++ b/TechTalk.SpecFlow/Bindings/AsyncMethodHelper.cs
@@ -15,13 +15,20 @@ namespace TechTalk.SpecFlow.Bindings
 
         private static bool IsTaskOfT(Type type, out Type typeArg)
         {
-            typeArg = null;
-            var isTaskOfT = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>);
-            if (isTaskOfT)
+            while (type != null)
             {
-                typeArg = type.GetGenericArguments()[0];
+                var isTaskOfT = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>);
+                if (isTaskOfT)
+                {
+                    typeArg = type.GetGenericArguments()[0];
+                    if (typeArg != typeof(void) && typeArg.FullName != "System.Threading.Tasks.VoidTaskResult")
+                        return true;
+                }
+                type = type.BaseType;
             }
-            return isTaskOfT;
+
+            typeArg = null;
+            return false;
         }
 
         private static bool IsValueTask(Type type)
@@ -99,6 +106,17 @@ namespace TechTalk.SpecFlow.Bindings
             if (bindingMethod is RuntimeBindingMethod runtimeBindingMethod) 
                 return IsAsyncVoid(runtimeBindingMethod.MethodInfo);
             return false;
+        }
+
+        public static Task<object> ConvertToTaskOfObject(Task task)
+        {
+            if (task.GetType() == typeof(Task))
+                return task.ContinueWith(_ => (object)null);
+            if (task is Task<object> taskOfObj)
+                return taskOfObj;
+            if (IsTaskOfT(task.GetType(), out _))
+                return task.ContinueWith(t => t.GetType().GetProperty(nameof(Task<object>.Result))!.GetValue(t));
+            return task.ContinueWith(_ => (object)null); // e.g. when this is a TaskBuilder
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/BindingDelegateInvoker.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingDelegateInvoker.cs
@@ -6,30 +6,51 @@ namespace TechTalk.SpecFlow.Bindings
 {
     public class BindingDelegateInvoker : IBindingDelegateInvoker
     {
-#if NETCOREAPP
         private ExecutionContext _executionContext = null;
-#endif
 
         public virtual async Task<object> InvokeDelegateAsync(Delegate bindingDelegate, object[] invokeArgs)
         {
-#if NETCOREAPP
-            if (_executionContext == null)
-                _executionContext = ExecutionContext.Capture();
-            else
-                ExecutionContext.Restore(_executionContext);
-#endif        
+            // To be able to simulate the behavior of sequential async or sync steps in a test, we need to ensure that
+            // the next step continues with the ExecutionContext that the previous step finished with. 
+            //
+            // Without preserving the ExecutionContext this would not happen because the async methods all the way up to the 
+            // generated test method (for example this method) are discarding the ExecutionContext changes at the end, so the 
+            // next step would start with an "empty" ExecutionContext again.
+            //
+            // It is important that no methods from here (until the user's binding method) is marked with 'async' otherwise that
+            // would again discard the ExecutionContext.
+            //
+            // The ExecutionContext only flows down, so async binding methods cannot directly change it, but even if all binding method
+            // is async the constructor of the binding classes are run in sync, so they should be able to change the ExecutionContext. 
+            // (The binding classes are created as part of the 'bindingDelegate' this method receives.
+
             try
             {
-                if (AsyncMethodHelper.IsAwaitable(bindingDelegate.Method.ReturnType))
-                    return await InvokeBindingDelegateAsync2(bindingDelegate, invokeArgs);
-                return InvokeBindingDelegateSync(bindingDelegate, invokeArgs);
+                return await InvokeInExecutionContext(_executionContext, () => CreateDelegateInvocationTask(bindingDelegate, invokeArgs));
             }
             finally
             {
-#if NETCOREAPP
                 _executionContext = ExecutionContext.Capture();
-#endif
             }
+        }
+
+        private Task<object> InvokeInExecutionContext(ExecutionContext executionContext, Func<Task<object>> callback)
+        {
+            if (executionContext == null)
+                return callback();
+
+            Task<object> result = Task.FromResult((object)null);
+            ExecutionContext.Run(executionContext, _ => { result = callback(); }, null);
+            return result;
+        }
+
+        // this method must not be async because that would discard the ExecutionContext changes during execution!
+        private Task<object> CreateDelegateInvocationTask(Delegate bindingDelegate, object[] invokeArgs)
+        {
+            if (AsyncMethodHelper.IsAwaitable(bindingDelegate.Method.ReturnType))
+                return InvokeBindingDelegateAsync(bindingDelegate, invokeArgs);
+
+            return Task.FromResult(InvokeBindingDelegateSync(bindingDelegate, invokeArgs));
         }
 
         protected virtual object InvokeBindingDelegateSync(Delegate bindingDelegate, object[] invokeArgs)
@@ -37,15 +58,8 @@ namespace TechTalk.SpecFlow.Bindings
             return bindingDelegate.DynamicInvoke(invokeArgs);
         }
 
-        protected virtual async Task<object> InvokeBindingDelegateAsync(Delegate bindingDelegate, object[] invokeArgs)
-        {
-            var result = bindingDelegate.DynamicInvoke(invokeArgs);
-            if (AsyncMethodHelper.IsAwaitableAsTask(result, out var task))
-                await task;
-            return result;
-        }
-
-        protected virtual Task<object> InvokeBindingDelegateAsync2(Delegate bindingDelegate, object[] invokeArgs)
+        // this method must not be async because that would discard the ExecutionContext changes during execution!
+        private Task<object> InvokeBindingDelegateAsync(Delegate bindingDelegate, object[] invokeArgs)
         {
             var result = bindingDelegate.DynamicInvoke(invokeArgs);
             if (AsyncMethodHelper.IsAwaitableAsTask(result, out var task))

--- a/TechTalk.SpecFlow/Bindings/BindingDelegateInvoker.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingDelegateInvoker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,9 +7,7 @@ namespace TechTalk.SpecFlow.Bindings
 {
     public class BindingDelegateInvoker : IBindingDelegateInvoker
     {
-        private ExecutionContext _executionContext = null;
-
-        public virtual async Task<object> InvokeDelegateAsync(Delegate bindingDelegate, object[] invokeArgs)
+        public virtual async Task<object> InvokeDelegateAsync(Delegate bindingDelegate, object[] invokeArgs, ExecutionContextHolder executionContext)
         {
             // To be able to simulate the behavior of sequential async or sync steps in a test, we need to ensure that
             // the next step continues with the ExecutionContext that the previous step finished with. 
@@ -26,11 +25,12 @@ namespace TechTalk.SpecFlow.Bindings
 
             try
             {
-                return await InvokeInExecutionContext(_executionContext, () => CreateDelegateInvocationTask(bindingDelegate, invokeArgs));
+                return await InvokeInExecutionContext(executionContext?.Value, () => CreateDelegateInvocationTask(bindingDelegate, invokeArgs));
             }
             finally
             {
-                _executionContext = ExecutionContext.Capture();
+                if (executionContext != null)
+                    executionContext.Value = ExecutionContext.Capture();
             }
         }
 

--- a/TechTalk.SpecFlow/Bindings/BindingDelegateInvoker.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingDelegateInvoker.cs
@@ -1,15 +1,35 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace TechTalk.SpecFlow.Bindings
 {
     public class BindingDelegateInvoker : IBindingDelegateInvoker
     {
+#if NETCOREAPP
+        private ExecutionContext _executionContext = null;
+#endif
+
         public virtual async Task<object> InvokeDelegateAsync(Delegate bindingDelegate, object[] invokeArgs)
         {
-            if (AsyncMethodHelper.IsAwaitable(bindingDelegate.Method.ReturnType))
-                return await InvokeBindingDelegateAsync(bindingDelegate, invokeArgs);
-            return InvokeBindingDelegateSync(bindingDelegate, invokeArgs);
+#if NETCOREAPP
+            if (_executionContext == null)
+                _executionContext = ExecutionContext.Capture();
+            else
+                ExecutionContext.Restore(_executionContext);
+#endif        
+            try
+            {
+                if (AsyncMethodHelper.IsAwaitable(bindingDelegate.Method.ReturnType))
+                    return await InvokeBindingDelegateAsync2(bindingDelegate, invokeArgs);
+                return InvokeBindingDelegateSync(bindingDelegate, invokeArgs);
+            }
+            finally
+            {
+#if NETCOREAPP
+                _executionContext = ExecutionContext.Capture();
+#endif
+            }
         }
 
         protected virtual object InvokeBindingDelegateSync(Delegate bindingDelegate, object[] invokeArgs)
@@ -23,6 +43,18 @@ namespace TechTalk.SpecFlow.Bindings
             if (AsyncMethodHelper.IsAwaitableAsTask(result, out var task))
                 await task;
             return result;
+        }
+
+        protected virtual Task<object> InvokeBindingDelegateAsync2(Delegate bindingDelegate, object[] invokeArgs)
+        {
+            var result = bindingDelegate.DynamicInvoke(invokeArgs);
+            if (AsyncMethodHelper.IsAwaitableAsTask(result, out var task))
+            {
+                if (task is Task<object> taskOfObj)
+                    return taskOfObj;
+                return task.ContinueWith(_ => (object)null);
+            }
+            return Task.FromResult(result);
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/ExecutionContextHolder.cs
+++ b/TechTalk.SpecFlow/Bindings/ExecutionContextHolder.cs
@@ -1,0 +1,8 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace TechTalk.SpecFlow.Bindings;
+
+public class ExecutionContextHolder : StrongBox<ExecutionContext>
+{
+}

--- a/TechTalk.SpecFlow/Bindings/IBindingDelegateInvoker.cs
+++ b/TechTalk.SpecFlow/Bindings/IBindingDelegateInvoker.cs
@@ -5,6 +5,6 @@ namespace TechTalk.SpecFlow.Bindings
 {
     public interface IBindingDelegateInvoker
     {
-        Task<object> InvokeDelegateAsync(Delegate bindingDelegate, object[] invokeArgs);
+        Task<object> InvokeDelegateAsync(Delegate bindingDelegate, object[] invokeArgs, ExecutionContextHolder executionContext);
     }
 }

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -336,7 +336,7 @@ namespace TechTalk.SpecFlow.Infrastructure
                 {
                     await InvokeHookAsync(_bindingInvoker, hookBinding, hookType);
                 }
-        }
+            }
             catch (Exception hookExceptionCaught)
             {
                 hookException = hookExceptionCaught;

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingInvokerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingInvokerTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using BoDi;
 using FluentAssertions;
@@ -163,4 +165,173 @@ public class BindingInvokerTests
     }
 
     #endregion
+    
+    #region ExecutionContext / AsyncLocal<T> related tests
+
+    public enum AsyncLocalType
+    {
+        Uninitialized,
+        CtorInitialized,
+        StaticCtorInitialized,
+        Boxed
+    }
+
+    class StepDefClassWithAsyncLocal
+    {
+        private readonly AsyncLocal<string> UninitializedAsyncLocal = new();
+        private readonly AsyncLocal<string> CtorInitializedAsyncLocal = new(ValueChangedHandler) { Value = "42" };
+        private static readonly AsyncLocal<string> StaticCtorInitializedAsyncLocal = new() { Value = "42" };
+        private readonly AsyncLocal<StrongBox<string>> BoxedAsyncLocal = new(ValueChangedHandlerBoxed) { Value = new StrongBox<string>("42") };
+
+        private static void ValueChangedHandler(AsyncLocalValueChangedArgs<string> obj)
+        {
+            _testOutputHelperInstance?.WriteLine($"{obj.PreviousValue} -> {obj.CurrentValue} ThreadContextChanged: {obj.ThreadContextChanged}");
+            //_testOutputHelperInstance?.WriteLine(Environment.StackTrace);
+        }
+
+        private static void ValueChangedHandlerBoxed(AsyncLocalValueChangedArgs<StrongBox<string>> obj)
+        {
+            //_testOutputHelperInstance.WriteLine($"{obj.PreviousValue} -> {obj.CurrentValue} ({obj.ThreadContextChanged})");
+        }
+
+        public string LoadedValue { get; set; }
+
+        public void SetAsyncLocal_Sync(AsyncLocalType asyncLocalType)
+        {
+            switch (asyncLocalType)
+            {
+                case AsyncLocalType.Uninitialized:
+                    UninitializedAsyncLocal.Value = "42";
+                    break;
+                case AsyncLocalType.CtorInitialized:
+                    CtorInitializedAsyncLocal.Value = "42";
+                    break;
+                case AsyncLocalType.StaticCtorInitialized:
+                    StaticCtorInitializedAsyncLocal.Value = "42";
+                    break;
+                case AsyncLocalType.Boxed:
+                    BoxedAsyncLocal.Value!.Value = "42";
+                    break;
+            }
+        }
+
+        public async Task SetAsyncLocal_Async(AsyncLocalType asyncLocalType)
+        {
+            switch (asyncLocalType)
+            {
+                case AsyncLocalType.Uninitialized:
+                    UninitializedAsyncLocal.Value = "42";
+                    break;
+                case AsyncLocalType.CtorInitialized:
+                    CtorInitializedAsyncLocal.Value = "42";
+                    break;
+                case AsyncLocalType.StaticCtorInitialized:
+                    StaticCtorInitializedAsyncLocal.Value = "42";
+                    break;
+                case AsyncLocalType.Boxed:
+                    BoxedAsyncLocal.Value!.Value = "42";
+                    break;
+            }
+            await Task.Delay(1);
+        }
+
+        public void GetAsyncLocal_Sync(AsyncLocalType asyncLocalType, string expectedResult)
+        {
+            LoadedValue = "GetAsyncLocal_Sync";
+            switch (asyncLocalType)
+            {
+                case AsyncLocalType.Uninitialized:
+                    LoadedValue = UninitializedAsyncLocal.Value;
+                    break;
+                case AsyncLocalType.CtorInitialized:
+                    LoadedValue = CtorInitializedAsyncLocal.Value;
+                    break;
+                case AsyncLocalType.StaticCtorInitialized:
+                    LoadedValue = StaticCtorInitializedAsyncLocal.Value;
+                    break;
+                case AsyncLocalType.Boxed:
+                    LoadedValue = BoxedAsyncLocal.Value?.Value;
+                    break;
+            }
+            Assert.Equal(expectedResult, LoadedValue);
+        }
+
+        public async Task GetAsyncLocal_Async(AsyncLocalType asyncLocalType, string expectedResult)
+        {
+            _testOutputHelperInstance.WriteLine("reading");
+            LoadedValue = "GetAsyncLocal_Async";
+            switch (asyncLocalType)
+            {
+                case AsyncLocalType.Uninitialized:
+                    LoadedValue = UninitializedAsyncLocal.Value;
+                    break;
+                case AsyncLocalType.CtorInitialized:
+                    LoadedValue = CtorInitializedAsyncLocal.Value;
+                    break;
+                case AsyncLocalType.StaticCtorInitialized:
+                    LoadedValue = StaticCtorInitializedAsyncLocal.Value;
+                    break;
+                case AsyncLocalType.Boxed:
+                    LoadedValue = BoxedAsyncLocal.Value?.Value;
+                    break;
+            }
+            Assert.Equal(expectedResult, LoadedValue);
+            await Task.Delay(1);
+        }
+    }
+
+
+    [Fact]
+    public async Task Test1()
+    {
+        var sut = CreateSut();
+        var contextManager = CreateContextManagerWith();
+
+        var al = AsyncLocalType.CtorInitialized;
+
+        //contextManager.ScenarioContext.ScenarioContainer.Resolve<StepDefClass>();
+
+        _testOutputHelper.WriteLine("M1");
+        await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), nameof(StepDefClassWithAsyncLocal.SetAsyncLocal_Sync), al);
+        _testOutputHelper.WriteLine("/M1");
+        _testOutputHelper.WriteLine("M2");
+        await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), nameof(StepDefClassWithAsyncLocal.GetAsyncLocal_Async), al, "42");
+        _testOutputHelper.WriteLine("/M2");
+
+        var stepDefClass = contextManager.ScenarioContext.ScenarioContainer.Resolve<StepDefClassWithAsyncLocal>();
+        stepDefClass.LoadedValue.Should().Be("42");
+    }
+
+    [Theory]
+    [InlineData("Case 1/a", AsyncLocalType.Uninitialized, "Sync", "Sync", "42")]
+    [InlineData("Case 1/b", AsyncLocalType.Uninitialized, "Sync", "Async", "42")]
+    [InlineData("Case 2/a", AsyncLocalType.CtorInitialized, null, "Sync", "42")]
+    [InlineData("Case 2/b", AsyncLocalType.CtorInitialized, null, "Async", "42")]
+    [InlineData("Case 2x/a", AsyncLocalType.CtorInitialized, "Sync", "Sync", "42")]
+    [InlineData("Case 2x/b", AsyncLocalType.CtorInitialized, "Async", "Async", "42")]
+    //[InlineData("Case 3/a", AsyncLocalType.StaticCtorInitialized, null, "Sync", "42")]
+    //[InlineData("Case 3/b", AsyncLocalType.StaticCtorInitialized, null, "Async", "42")]
+    [InlineData("Case 4/a", AsyncLocalType.Uninitialized, "Async", "Sync", null)]
+    [InlineData("Case 4/b", AsyncLocalType.Uninitialized, "Async", "Async", null)]
+    [InlineData("Case 6/a", AsyncLocalType.Boxed, "Sync", "Sync", "42")]
+    [InlineData("Case 6/b", AsyncLocalType.Boxed, "Sync", "Async", "42")]
+    [InlineData("Case 7/a", AsyncLocalType.Boxed, null, "Sync", "42")]
+    [InlineData("Case 7/b", AsyncLocalType.Boxed, null, "Async", "42")]
+    [InlineData("Case 8/a", AsyncLocalType.Boxed, "Async", "Sync", "42")]
+    [InlineData("Case 8/b", AsyncLocalType.Boxed, "Async", "Async", "42")]
+    public async Task ExecutionContext_is_flowing_down_correctly_to_step_definitions(string description, AsyncLocalType asyncLocalType, string setAs, string getAs, string expectedResult)
+    {
+        _testOutputHelper.WriteLine(description);
+        var sut = CreateSut();
+        var contextManager = CreateContextManagerWith();
+
+        if (setAs != null)
+            await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), "SetAsyncLocal_" + setAs, asyncLocalType);
+        await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), "GetAsyncLocal_" + getAs, asyncLocalType, expectedResult);
+
+        var stepDefClass = contextManager.ScenarioContext.ScenarioContainer.Resolve<StepDefClassWithAsyncLocal>();
+        stepDefClass.LoadedValue.Should().Be(expectedResult, $"Error was not propagated for {description}");
+    }
+
+    #endregion   
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingInvokerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingInvokerTests.cs
@@ -32,22 +32,6 @@ public class BindingInvokerTests
         return new BindingInvoker(ConfigurationLoader.GetDefault(), new StubErrorProvider(), new BindingDelegateInvoker());
     }
 
-    class SampleStepDefClass
-    {
-        public string CapturedValue = null;
-
-        public void SampleSyncStepDef(int someParam)
-        {
-            _testOutputHelperInstance.WriteLine($"some info here: {someParam}");
-        }
-
-        public async Task SampleAsyncStepDef(string otherParam)
-        {
-            _testOutputHelperInstance.WriteLine($"some info here: {otherParam}");
-            CapturedValue = otherParam;
-        }
-    }
-
     class TestableMethodBinding : MethodBinding
     {
         public TestableMethodBinding(IBindingMethod bindingMethod) : base(bindingMethod)
@@ -55,11 +39,11 @@ public class BindingInvokerTests
         }
     }
 
-    private async Task InvokeBindingAsync(BindingInvoker sut, IContextManager contextManager, Type stepDefType, string methodName, params object[] args)
+    private async Task<object> InvokeBindingAsync(BindingInvoker sut, IContextManager contextManager, Type stepDefType, string methodName, params object[] args)
     {
         var testTracerMock = new Mock<ITestTracer>();
         var setMethodBinding = new TestableMethodBinding(new RuntimeBindingMethod(stepDefType.GetMethod(methodName)));
-        await sut.InvokeBindingAsync(setMethodBinding, contextManager, args, testTracerMock.Object, new DurationHolder());
+        return await sut.InvokeBindingAsync(setMethodBinding, contextManager, args, testTracerMock.Object, new DurationHolder());
     }
 
     private IContextManager CreateContextManagerWith()
@@ -72,21 +56,79 @@ public class BindingInvokerTests
         return contextManager;
     }
 
-    [Fact]
-    public async Task Sample_binding_invoker_test()
+    #region Generic invokation tests
+
+    class GenericStepDefClass
     {
-        _testOutputHelper.WriteLine("starting sample test");
+        public bool WasInvoked = false;
+        public int CapturedIntParam = 0;
+        public string CapturedStringParam = null;
+
+        public void SyncStepDef(int intParam, string stringParam)
+        {
+            WasInvoked = true;
+            CapturedIntParam = intParam;
+            CapturedStringParam = stringParam;
+        }
+
+        public async Task AsyncStepDef(int intParam, string stringParam)
+        {
+            await Task.Delay(10);
+            WasInvoked = true;
+            CapturedIntParam = intParam;
+            CapturedStringParam = stringParam;
+        }
+
+        public async Task<int> AsyncConverter(int intParam, string stringParam)
+        {
+            await Task.Delay(10);
+            WasInvoked = true;
+            CapturedIntParam = intParam;
+            CapturedStringParam = stringParam;
+            return 42;
+        }
+
+        public async Task<int> AsyncConverterWithoutAwait(int intParam, string stringParam)
+        {
+            WasInvoked = true;
+            CapturedIntParam = intParam;
+            CapturedStringParam = stringParam;
+            return 42;
+        }
+
+        public int SyncConverter(int intParam, string stringParam)
+        {
+            WasInvoked = true;
+            CapturedIntParam = intParam;
+            CapturedStringParam = stringParam;
+            return 42;
+        }
+    }
+
+
+    [Theory]
+    [InlineData(nameof(GenericStepDefClass.SyncStepDef), null)]
+    [InlineData(nameof(GenericStepDefClass.AsyncStepDef), null)]
+    [InlineData(nameof(GenericStepDefClass.SyncConverter), 42)]
+    [InlineData(nameof(GenericStepDefClass.AsyncConverter), 42)]
+    [InlineData(nameof(GenericStepDefClass.AsyncConverterWithoutAwait), 42)]
+    public async Task Can_invoke_different_methods(string methodName, object expectedResult)
+    {
         var sut = CreateSut();
         var contextManager = CreateContextManagerWith();
 
         // call step definition methods
-        await InvokeBindingAsync(sut, contextManager, typeof(SampleStepDefClass), nameof(SampleStepDefClass.SampleSyncStepDef), 42);
-        await InvokeBindingAsync(sut, contextManager, typeof(SampleStepDefClass), nameof(SampleStepDefClass.SampleAsyncStepDef), "42");
+        var result = await InvokeBindingAsync(sut, contextManager, typeof(GenericStepDefClass), methodName, 24, "foo");
 
         // this is how to get THE instance of the step definition class
-        var stepDefClass = contextManager.ScenarioContext.ScenarioContainer.Resolve<SampleStepDefClass>();
-        stepDefClass.CapturedValue.Should().Be("42");
+        var stepDefClass = contextManager.ScenarioContext.ScenarioContainer.Resolve<GenericStepDefClass>();
+        stepDefClass.WasInvoked.Should().BeTrue();
+        stepDefClass.CapturedIntParam.Should().Be(24);
+        stepDefClass.CapturedStringParam.Should().Be("foo");
+        result.Should().Be(expectedResult);
     }
+
+    #endregion
 
     #region ValueTask related tests
 
@@ -309,8 +351,6 @@ public class BindingInvokerTests
     [InlineData("Case 2/b", AsyncLocalType.CtorInitialized, null, "Async", "42")]
     [InlineData("Case 2x/a", AsyncLocalType.CtorInitialized, "Sync", "Sync", "42")]
     [InlineData("Case 2x/b", AsyncLocalType.CtorInitialized, "Async", "Async", "42")]
-    //[InlineData("Case 3/a", AsyncLocalType.StaticCtorInitialized, null, "Sync", "42")]
-    //[InlineData("Case 3/b", AsyncLocalType.StaticCtorInitialized, null, "Async", "42")]
     [InlineData("Case 4/a", AsyncLocalType.Uninitialized, "Async", "Sync", null)]
     [InlineData("Case 4/b", AsyncLocalType.Uninitialized, "Async", "Async", null)]
     [InlineData("Case 6/a", AsyncLocalType.Boxed, "Sync", "Sync", "42")]


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

This PR fixes #2600 by saving and reusing the ExecutionContext for the subsequent binding method invocations. ExecutionContext is pretty complex and hard to understand and also the behavior of `AsyncLocal<T>` is not straightforward to understand. 

The bottom line is: `AsyncLocal<T>` now works as in SpecFlow v3 (and is it supposed to): you can change the value in ctor and sync step definitions, but the changes in async step definitions are discarded (this is how ExecutionContext works).

If you want to use  `AsyncLocal<T>` and be able to change it in sync/async step definitions, you should use  `AsyncLocal<StrongBox<T>>` and initialize it in ctor, like:
```
private readonly AsyncLocal<StrongBox<string>> _boxedAsyncLocal = new() { Value = new StrongBox<string>("ctor-value") };
```

A bit more tech detail (also included in `BindingDelegateInvoker` as comment):

To be able to simulate the behavior of sequential async or sync steps in a test, we need to ensure that the next step continues with the ExecutionContext that the previous step finished with. 

Without preserving the ExecutionContext this would not happen because the async methods all the way up to the generated test method (for example this method) are discarding the ExecutionContext changes at the end, so the next step would start with an "empty" ExecutionContext again.

It is important that no methods from here (until the user's binding method) is marked with 'async' otherwise that would again discard the ExecutionContext.

The ExecutionContext only flows down, so async binding methods cannot directly change it, but even if all binding method is async the constructor of the binding classes are run in sync, so they should be able to change the ExecutionContext. (The binding classes are created as part of the 'bindingDelegate' this method receives.


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This is to avoid a breaking change in v4, so no need to add an entry to chanelog.