### PR TITLE
Disallow async void bindings 2657

### DIFF
--- a/TechTalk.SpecFlow/Bindings/AsyncMethodHelper.cs
+++ b/TechTalk.SpecFlow/Bindings/AsyncMethodHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using TechTalk.SpecFlow.Bindings.Reflection;
 
@@ -83,6 +85,20 @@ namespace TechTalk.SpecFlow.Bindings
             }
 
             return returnType;
+        }
+
+        public static bool IsAsyncVoid(MethodInfo methodInfo)
+        {
+            return 
+                methodInfo.ReturnType == typeof(void) &&
+                methodInfo.GetCustomAttribute<AsyncStateMachineAttribute>() != null;
+        }
+
+        public static bool IsAsyncVoid(IBindingMethod bindingMethod)
+        {
+            if (bindingMethod is RuntimeBindingMethod runtimeBindingMethod) 
+                return IsAsyncVoid(runtimeBindingMethod.MethodInfo);
+            return false;
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/BindingInvoker.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingInvoker.cs
@@ -117,6 +117,9 @@ namespace TechTalk.SpecFlow.Bindings
 
         protected virtual Delegate CreateMethodDelegate(MethodInfo method)
         {
+            if (AsyncMethodHelper.IsAsyncVoid(method)) 
+                throw new SpecFlowException($"Invalid binding method '{method.DeclaringType!.FullName}.{method.Name}()': async void methods are not supported. Please use 'async Task'.");
+
             List<ParameterExpression> parameters = new List<ParameterExpression>();
             parameters.Add(Expression.Parameter(typeof(IContextManager), "__contextManager"));
             parameters.AddRange(method.GetParameters().Select(parameterInfo => Expression.Parameter(parameterInfo.ParameterType, parameterInfo.Name)));

--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
@@ -265,6 +265,9 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
             if (currentBindingSourceType.IsAbstract && !bindingSourceMethod.IsStatic && OnValidationError("Abstract binding types can have only static binding methods: {0}", bindingSourceMethod))
                 return false;
 
+            if (AsyncMethodHelper.IsAsyncVoid(bindingSourceMethod.BindingMethod) && OnValidationError("Invalid binding method '{0}': async void methods are not supported. Please use 'async Task'.", bindingSourceMethod))
+                return false;
+
             return true;
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSourceProcessorStub.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSourceProcessorStub.cs
@@ -8,9 +8,10 @@ namespace TechTalk.SpecFlow.RuntimeTests
 {
     public class BindingSourceProcessorStub : BindingSourceProcessor, IRuntimeBindingSourceProcessor
     {
-        public readonly List<IStepDefinitionBinding> StepDefinitionBindings = new List<IStepDefinitionBinding>();
-        public readonly List<IHookBinding> HookBindings = new List<IHookBinding>();
-        public readonly List<IStepArgumentTransformationBinding> StepArgumentTransformationBindings = new List<IStepArgumentTransformationBinding>();
+        public readonly List<IStepDefinitionBinding> StepDefinitionBindings = new();
+        public readonly List<IHookBinding> HookBindings = new();
+        public readonly List<IStepArgumentTransformationBinding> StepArgumentTransformationBindings = new();
+        public readonly List<string> ValidationErrors = new();
 
         public BindingSourceProcessorStub() : base(new BindingFactory(new StepDefinitionRegexCalculator(ConfigurationLoader.GetDefault()), new CucumberExpressionStepDefinitionBindingBuilderFactory(new CucumberExpressionParameterTypeRegistry(new BindingRegistry()))))
         {
@@ -29,6 +30,12 @@ namespace TechTalk.SpecFlow.RuntimeTests
         protected override void ProcessStepArgumentTransformationBinding(IStepArgumentTransformationBinding stepArgumentTransformationBinding)
         {
             StepArgumentTransformationBindings.Add(stepArgumentTransformationBinding);
+        }
+
+        protected override bool OnValidationError(string messageFormat, params object[] arguments)
+        {
+            ValidationErrors.Add(string.Format(messageFormat, arguments));
+            return base.OnValidationError(messageFormat, arguments);
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingInvokerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingInvokerTests.cs
@@ -134,4 +134,33 @@ public class BindingInvokerTests
     }
 
     #endregion
+
+    #region Async void related tests
+
+    class StepDefClassWithAsyncVoid
+    {
+        public static bool WasInvokedAsyncVoidStepDef = false;
+
+        public async void AsyncVoidStepDef()
+        {
+            await Task.Delay(50); // we need to wait a bit otherwise the assertion passes even if the method is called sync
+            WasInvokedAsyncVoidStepDef = true;
+        }
+    }
+
+    [Fact]
+    public async Task Async_void_binding_methods_are_not_supported()
+    {
+        var sut = CreateSut();
+        var contextManager = CreateContextManagerWith();
+
+        await FluentActions.Awaiting(() => InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncVoid), nameof(StepDefClassWithAsyncVoid.AsyncVoidStepDef)))
+                           .Should()
+                           .ThrowAsync<SpecFlowException>()
+                           .WithMessage("*async void*");
+
+        StepDefClassWithAsyncVoid.WasInvokedAsyncVoidStepDef.Should().BeFalse();
+    }
+
+    #endregion
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Breaking Changes:
 + Removed the ability to call steps from steps via string - https://github.com/SpecFlowOSS/SpecFlow/issues/1733
 + Removed .NET Core 2.1 support (min .NET Core version: 3.1)
 + Removed .NET Framework 4.6.1 support (min .NET Framework version: 4.6.2)
++ Bindigns declared as 'async void' are not allowed. Use 'async Task' instead.
 
 Features:
 + Add an option to colorize test result output


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

Fixes #2657 by explicitly disallowing `async void` binding methods.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
