### PR TITLE
Report binding problems to binding registry and show them as errors during test execution

### DIFF
--- a/TechTalk.SpecFlow/Bindings/BindingError.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingError.cs
@@ -1,0 +1,20 @@
+namespace TechTalk.SpecFlow.Bindings;
+
+public class BindingError
+{
+    public BindingErrorType Type { get; }
+    public string Message { get; }
+
+    public BindingError(BindingErrorType type, string message)
+    {
+        Type = type;
+        Message = message;
+    }
+}
+
+public enum BindingErrorType
+{
+    TypeLoadError,
+    BindingError,
+    StepDefinitionError,
+}

--- a/TechTalk.SpecFlow/Bindings/BindingRegistry.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingRegistry.cs
@@ -4,19 +4,12 @@ using System.Linq;
 
 namespace TechTalk.SpecFlow.Bindings
 {
-    public enum BindingErrorType
-    {
-        TypeLoadError,
-        BindingError,
-        StepDefinitionError,
-    }
-
     public class BindingRegistry : IBindingRegistry
     {
         private readonly List<IStepDefinitionBinding> _stepDefinitions = new();
         private readonly List<IStepArgumentTransformationBinding> _stepArgumentTransformations = new();
         private readonly Dictionary<HookType, List<IHookBinding>> _hooks = new();
-        private readonly List<(BindingErrorType ErrorType, string Message)> _genericBindingErrors = new();
+        private readonly List<BindingError> _genericBindingErrors = new();
 
         public bool Ready { get; set; }
 
@@ -56,14 +49,14 @@ namespace TechTalk.SpecFlow.Bindings
             return _stepArgumentTransformations;
         }
 
-        public IEnumerable<(BindingErrorType ErrorType, string Message)> GetErrorMessages()
+        public IEnumerable<BindingError> GetErrorMessages()
         {
             foreach (var genericBindingError in _genericBindingErrors)
                 yield return genericBindingError;
 
             foreach (var stepDefinitionBinding in _stepDefinitions.Where(sd => !sd.IsValid))
             {
-                yield return (BindingErrorType.StepDefinitionError, stepDefinitionBinding.ErrorMessage);
+                yield return new BindingError(BindingErrorType.StepDefinitionError, stepDefinitionBinding.ErrorMessage);
             }
         }
 
@@ -96,9 +89,9 @@ namespace TechTalk.SpecFlow.Bindings
             _stepArgumentTransformations.Add(stepArgumentTransformationBinding);
         }
 
-        public void RegisterGenericBindingError(BindingErrorType errorType, string errorMessage)
+        public void RegisterGenericBindingError(BindingError error)
         {
-            _genericBindingErrors.Add((errorType, errorMessage));
+            _genericBindingErrors.Add(error);
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/BindingRegistry.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingRegistry.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -5,26 +6,29 @@ namespace TechTalk.SpecFlow.Bindings
 {
     public class BindingRegistry : IBindingRegistry
     {
-        private readonly List<IStepDefinitionBinding> stepDefinitions = new List<IStepDefinitionBinding>();
-        private readonly List<IStepArgumentTransformationBinding> stepArgumentTransformations = new List<IStepArgumentTransformationBinding>();
-        private readonly Dictionary<HookType, List<IHookBinding>> hooks = new Dictionary<HookType, List<IHookBinding>>();
+        private readonly List<IStepDefinitionBinding> _stepDefinitions = new();
+        private readonly List<IStepArgumentTransformationBinding> _stepArgumentTransformations = new();
+        private readonly Dictionary<HookType, List<IHookBinding>> _hooks = new();
+        private readonly List<string> _genericBindingErrors = new();
 
         public bool Ready { get; set; }
 
+        public bool IsValid => !GetErrorMessages().Any();
+
         public IEnumerable<IStepDefinitionBinding> GetStepDefinitions()
         {
-            return stepDefinitions;
+            return _stepDefinitions;
         }
 
         public IEnumerable<IStepDefinitionBinding> GetConsideredStepDefinitions(StepDefinitionType stepDefinitionType, string stepText)
         {
             //TODO: later optimize to return step definitions that has a chance to match to stepText
-            return stepDefinitions.Where(sd => sd.StepDefinitionType == stepDefinitionType);
+            return _stepDefinitions.Where(sd => sd.StepDefinitionType == stepDefinitionType);
         }
 
         public virtual IEnumerable<IHookBinding> GetHooks()
         {
-            return hooks.Values.SelectMany(hookList => hookList);
+            return _hooks.Values.SelectMany(hookList => hookList);
         }
 
         public virtual IEnumerable<IHookBinding> GetHooks(HookType bindingEvent)
@@ -34,7 +38,7 @@ namespace TechTalk.SpecFlow.Bindings
 
         private IEnumerable<IHookBinding> GetHookList(HookType bindingEvent)
         {
-            if (hooks.TryGetValue(bindingEvent, out var list))
+            if (_hooks.TryGetValue(bindingEvent, out var list))
                 return list;
 
             return Enumerable.Empty<IHookBinding>();
@@ -42,20 +46,31 @@ namespace TechTalk.SpecFlow.Bindings
 
         public virtual IEnumerable<IStepArgumentTransformationBinding> GetStepTransformations()
         {
-            return stepArgumentTransformations;
+            return _stepArgumentTransformations;
+        }
+
+        public IEnumerable<string> GetErrorMessages()
+        {
+            foreach (string genericBindingError in _genericBindingErrors)
+                yield return genericBindingError;
+
+            foreach (var stepDefinitionBinding in _stepDefinitions.Where(sd => !sd.IsValid))
+            {
+                yield return stepDefinitionBinding.ErrorMessage;
+            }
         }
 
         public virtual void RegisterStepDefinitionBinding(IStepDefinitionBinding stepDefinitionBinding)
         {
-            stepDefinitions.Add(stepDefinitionBinding);
+            _stepDefinitions.Add(stepDefinitionBinding);
         }
 
         private List<IHookBinding> GetHookListForRegister(HookType bindingEvent)
         {
-            if (!hooks.TryGetValue(bindingEvent, out var list))
+            if (!_hooks.TryGetValue(bindingEvent, out var list))
             {
                 list = new List<IHookBinding>();
-                hooks.Add(bindingEvent, list);
+                _hooks.Add(bindingEvent, list);
             }
 
             return list;
@@ -71,7 +86,12 @@ namespace TechTalk.SpecFlow.Bindings
 
         public virtual void RegisterStepArgumentTransformationBinding(IStepArgumentTransformationBinding stepArgumentTransformationBinding)
         {
-            stepArgumentTransformations.Add(stepArgumentTransformationBinding);
+            _stepArgumentTransformations.Add(stepArgumentTransformationBinding);
+        }
+
+        public void RegisterGenericBindingError(string errorMessage)
+        {
+            _genericBindingErrors.Add(errorMessage);
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceMethod.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceMethod.cs
@@ -9,5 +9,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         public bool IsStatic { get; set; }
 
         public BindingSourceAttribute[] Attributes { get; set; }
+
+        public override string ToString() => BindingMethod.ToString();
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
@@ -277,6 +277,11 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
                 ErrorMessages = new List<string> { errorMessage };
             }
 
+            private BindingValidationResult(List<string> errorMessages)
+            {
+                ErrorMessages = new List<string>(errorMessages);
+            }
+
             public bool IsValid => ErrorMessages == null || ErrorMessages.Count == 0;
 
             public string CombinedErrorMessages => string.Join(", ", ErrorMessages);
@@ -285,8 +290,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
             {
                 if (r1.IsValid) return r2;
                 if (r2.IsValid) return r1;
-                var result = new BindingValidationResult();
-                result.ErrorMessages.AddRange(r1.ErrorMessages);
+                var result = new BindingValidationResult(r1.ErrorMessages);
                 result.ErrorMessages.AddRange(r2.ErrorMessages);
                 return result;
             }

--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceType.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceType.cs
@@ -13,5 +13,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         public bool IsNested { get; set; }
 
         public BindingSourceAttribute[] Attributes { get; set; }
+
+        public override string ToString() => BindingType?.ToString() ?? "<null>";
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Discovery/RuntimeBindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/RuntimeBindingSourceProcessor.cs
@@ -42,7 +42,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
             {
                 _testTracer.TraceWarning($"Invalid binding: {errorMessage}");
                 if (genericBindingError)
-                    _bindingRegistry.RegisterGenericBindingError(BindingErrorType.BindingError, errorMessage);
+                    _bindingRegistry.RegisterGenericBindingError(new BindingError(BindingErrorType.BindingError, errorMessage));
             }
 
             base.OnValidationError(validationResult, genericBindingError);
@@ -56,7 +56,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
         public void RegisterTypeLoadError(string errorMessage)
         {
-            _bindingRegistry.RegisterGenericBindingError(BindingErrorType.TypeLoadError, errorMessage);
+            _bindingRegistry.RegisterGenericBindingError(new BindingError(BindingErrorType.TypeLoadError, errorMessage));
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Discovery/RuntimeBindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/RuntimeBindingSourceProcessor.cs
@@ -1,5 +1,4 @@
-﻿using TechTalk.SpecFlow.ErrorHandling;
-using TechTalk.SpecFlow.Tracing;
+﻿using TechTalk.SpecFlow.Tracing;
 
 namespace TechTalk.SpecFlow.Bindings.Discovery
 {
@@ -9,52 +8,49 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
     public class RuntimeBindingSourceProcessor : BindingSourceProcessor, IRuntimeBindingSourceProcessor
     {
-        private readonly IBindingRegistry bindingRegistry;
-        private readonly IErrorProvider errorProvider;
-        private readonly ITestTracer testTracer;
+        private readonly IBindingRegistry _bindingRegistry;
+        private readonly ITestTracer _testTracer;
 
-        public RuntimeBindingSourceProcessor(IBindingFactory bindingFactory, IBindingRegistry bindingRegistry, IErrorProvider errorProvider, ITestTracer testTracer) : base(bindingFactory)
+        public RuntimeBindingSourceProcessor(IBindingFactory bindingFactory, IBindingRegistry bindingRegistry, ITestTracer testTracer) : base(bindingFactory)
         {
-            this.bindingRegistry = bindingRegistry;
-            this.errorProvider = errorProvider;
-            this.testTracer = testTracer;
+            _bindingRegistry = bindingRegistry;
+            _testTracer = testTracer;
         }
 
         protected override void ProcessStepDefinitionBinding(IStepDefinitionBinding stepDefinitionBinding)
         {
-            bindingRegistry.RegisterStepDefinitionBinding(stepDefinitionBinding);
+            _bindingRegistry.RegisterStepDefinitionBinding(stepDefinitionBinding);
         }
 
         protected override void ProcessHookBinding(IHookBinding hookBinding)
         {
-            bindingRegistry.RegisterHookBinding(hookBinding);
+            _bindingRegistry.RegisterHookBinding(hookBinding);
         }
 
         protected override void ProcessStepArgumentTransformationBinding(IStepArgumentTransformationBinding stepArgumentTransformationBinding)
         {
-            bindingRegistry.RegisterStepArgumentTransformationBinding(stepArgumentTransformationBinding);
+            _bindingRegistry.RegisterStepArgumentTransformationBinding(stepArgumentTransformationBinding);
         }
 
-        protected override bool OnValidationError(string messageFormat, params object[] arguments)
+        protected override void OnValidationError(BindingValidationResult validationResult, bool genericBindingError)
         {
-            testTracer.TraceWarning("Invalid binding: " + string.Format(messageFormat, arguments));
-            return false; //TODO: currently this is a warning only (hence return false), in v2 this will be changed
-        }
+            if (validationResult.IsValid)
+                return;
 
-        protected override bool ValidateHook(BindingSourceMethod bindingSourceMethod, BindingSourceAttribute hookAttribute, HookType hookType)
-        {
-            //TODO: this call will be refactored when binding error detecttion will be improved in v2 - currently implemented here for backwards compatibility
-            if (!IsScenarioSpecificHook(hookType) &&
-                !bindingSourceMethod.IsStatic)
-                throw errorProvider.GetNonStaticEventError(bindingSourceMethod.BindingMethod);
+            foreach (string errorMessage in validationResult.ErrorMessages)
+            {
+                _testTracer.TraceWarning($"Invalid binding: {errorMessage}");
+                if (genericBindingError)
+                    _bindingRegistry.RegisterGenericBindingError(errorMessage);
+            }
 
-            return base.ValidateHook(bindingSourceMethod, hookAttribute, hookType);
+            base.OnValidationError(validationResult, genericBindingError);
         }
 
         public override void BuildingCompleted()
         {
             base.BuildingCompleted();
-            bindingRegistry.Ready = true;
+            _bindingRegistry.Ready = true;
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Discovery/RuntimeBindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/RuntimeBindingSourceProcessor.cs
@@ -4,6 +4,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 {
     public interface IRuntimeBindingSourceProcessor : IBindingSourceProcessor
     {
+        void RegisterTypeLoadError(string errorMessage);
     }
 
     public class RuntimeBindingSourceProcessor : BindingSourceProcessor, IRuntimeBindingSourceProcessor
@@ -41,7 +42,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
             {
                 _testTracer.TraceWarning($"Invalid binding: {errorMessage}");
                 if (genericBindingError)
-                    _bindingRegistry.RegisterGenericBindingError(errorMessage);
+                    _bindingRegistry.RegisterGenericBindingError(BindingErrorType.BindingError, errorMessage);
             }
 
             base.OnValidationError(validationResult, genericBindingError);
@@ -51,6 +52,11 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         {
             base.BuildingCompleted();
             _bindingRegistry.Ready = true;
+        }
+
+        public void RegisterTypeLoadError(string errorMessage)
+        {
+            _bindingRegistry.RegisterGenericBindingError(BindingErrorType.TypeLoadError, errorMessage);
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/IBindingRegistry.cs
+++ b/TechTalk.SpecFlow/Bindings/IBindingRegistry.cs
@@ -12,11 +12,11 @@ namespace TechTalk.SpecFlow.Bindings
         IEnumerable<IStepDefinitionBinding> GetConsideredStepDefinitions(StepDefinitionType stepDefinitionType, string stepText = null);
         IEnumerable<IHookBinding> GetHooks(HookType bindingEvent);
         IEnumerable<IStepArgumentTransformationBinding> GetStepTransformations();
-        IEnumerable<string> GetErrorMessages();
+        IEnumerable<(BindingErrorType ErrorType, string Message)> GetErrorMessages();
 
         void RegisterStepDefinitionBinding(IStepDefinitionBinding stepDefinitionBinding);
         void RegisterHookBinding(IHookBinding hookBinding);
         void RegisterStepArgumentTransformationBinding(IStepArgumentTransformationBinding stepArgumentTransformationBinding);
-        void RegisterGenericBindingError(string errorMessage);
+        void RegisterGenericBindingError(BindingErrorType errorType, string errorMessage);
     }
 }

--- a/TechTalk.SpecFlow/Bindings/IBindingRegistry.cs
+++ b/TechTalk.SpecFlow/Bindings/IBindingRegistry.cs
@@ -12,11 +12,11 @@ namespace TechTalk.SpecFlow.Bindings
         IEnumerable<IStepDefinitionBinding> GetConsideredStepDefinitions(StepDefinitionType stepDefinitionType, string stepText = null);
         IEnumerable<IHookBinding> GetHooks(HookType bindingEvent);
         IEnumerable<IStepArgumentTransformationBinding> GetStepTransformations();
-        IEnumerable<(BindingErrorType ErrorType, string Message)> GetErrorMessages();
+        IEnumerable<BindingError> GetErrorMessages();
 
         void RegisterStepDefinitionBinding(IStepDefinitionBinding stepDefinitionBinding);
         void RegisterHookBinding(IHookBinding hookBinding);
         void RegisterStepArgumentTransformationBinding(IStepArgumentTransformationBinding stepArgumentTransformationBinding);
-        void RegisterGenericBindingError(BindingErrorType errorType, string errorMessage);
+        void RegisterGenericBindingError(BindingError error);
     }
 }

--- a/TechTalk.SpecFlow/Bindings/IBindingRegistry.cs
+++ b/TechTalk.SpecFlow/Bindings/IBindingRegistry.cs
@@ -5,15 +5,18 @@ namespace TechTalk.SpecFlow.Bindings
     public interface IBindingRegistry
     {
         bool Ready { get; set; }
+        bool IsValid { get; }
 
         IEnumerable<IStepDefinitionBinding> GetStepDefinitions();
         IEnumerable<IHookBinding> GetHooks();
         IEnumerable<IStepDefinitionBinding> GetConsideredStepDefinitions(StepDefinitionType stepDefinitionType, string stepText = null);
         IEnumerable<IHookBinding> GetHooks(HookType bindingEvent);
         IEnumerable<IStepArgumentTransformationBinding> GetStepTransformations();
+        IEnumerable<string> GetErrorMessages();
 
         void RegisterStepDefinitionBinding(IStepDefinitionBinding stepDefinitionBinding);
         void RegisterHookBinding(IHookBinding hookBinding);
         void RegisterStepArgumentTransformationBinding(IStepArgumentTransformationBinding stepArgumentTransformationBinding);
+        void RegisterGenericBindingError(string errorMessage);
     }
 }

--- a/TechTalk.SpecFlow/Bindings/InvalidStepDefinitionBindingBuilder.cs
+++ b/TechTalk.SpecFlow/Bindings/InvalidStepDefinitionBindingBuilder.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using TechTalk.SpecFlow.Bindings.Reflection;
+
+namespace TechTalk.SpecFlow.Bindings;
+
+public class InvalidStepDefinitionBindingBuilder : IStepDefinitionBindingBuilder
+{
+    private readonly StepDefinitionType _stepDefinitionType;
+    private readonly IBindingMethod _bindingMethod;
+    private readonly BindingScope _bindingScope;
+    private readonly string _sourceExpression;
+    private readonly string _errorMessage;
+
+    public InvalidStepDefinitionBindingBuilder(StepDefinitionType stepDefinitionType, IBindingMethod bindingMethod, BindingScope bindingScope, string sourceExpression, string errorMessage)
+    {
+        _stepDefinitionType = stepDefinitionType;
+        _bindingMethod = bindingMethod;
+        _bindingScope = bindingScope;
+        _sourceExpression = sourceExpression;
+        _errorMessage = errorMessage;
+    }
+
+    public IEnumerable<IStepDefinitionBinding> Build()
+    {
+        yield return StepDefinitionBinding.CreateInvalid(_stepDefinitionType, _bindingMethod, _bindingScope, StepDefinitionExpressionTypes.Unknown, _sourceExpression, _errorMessage);
+    }
+}

--- a/TechTalk.SpecFlow/Bindings/Reflection/BindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/BindingType.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public override string ToString()
         {
-            return $"[{AssemblyName}:{FullName}]";
+            return $"{AssemblyName}:{FullName}";
         }
 
         protected bool Equals(BindingType other)

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingMethod.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingMethod.cs
@@ -9,20 +9,11 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
     {
         public readonly MethodInfo MethodInfo;
 
-        public IBindingType Type
-        {
-            get { return new RuntimeBindingType(MethodInfo.DeclaringType); }
-        }
+        public IBindingType Type => new RuntimeBindingType(MethodInfo.DeclaringType);
 
-        public IBindingType ReturnType
-        {
-            get { return MethodInfo.ReturnType == typeof(void) ? null : new RuntimeBindingType(MethodInfo.ReturnType); }
-        }
+        public IBindingType ReturnType => MethodInfo.ReturnType == typeof(void) ? null : new RuntimeBindingType(MethodInfo.ReturnType);
 
-        public string Name
-        {
-            get { return MethodInfo.Name; }
-        }
+        public string Name => MethodInfo.Name;
 
         public IEnumerable<IBindingParameter> Parameters
         {
@@ -31,7 +22,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public RuntimeBindingMethod(MethodInfo methodInfo)
         {
-            this.MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+            MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
         }
 
         public override string ToString()
@@ -48,7 +39,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
+            if (obj.GetType() != GetType()) return false;
             return Equals((RuntimeBindingMethod) obj);
         }
 

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public RuntimeBindingType(Type type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         public bool IsAssignableTo(IBindingType baseType)
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public override string ToString()
         {
-            return "[" + Type + "]";
+            return Type.ToString();
         }
 
         protected bool Equals(RuntimeBindingType other)
@@ -36,7 +36,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
+            if (obj.GetType() != GetType()) return false;
             return Equals((RuntimeBindingType) obj);
         }
 
@@ -45,6 +45,6 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             return (Type != null ? Type.GetHashCode() : 0);
         }
 
-        public static readonly RuntimeBindingType Void = new RuntimeBindingType(typeof(void));
+        public static readonly RuntimeBindingType Void = new(typeof(void));
     }
 }

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -21,9 +21,9 @@ namespace TechTalk.SpecFlow.ErrorHandling
         PendingStepException GetPendingStepDefinitionError();
         void ThrowPendingError(ScenarioExecutionStatus testStatus, string message);
         Exception GetTooManyBindingParamError(int maxParam);
-        Exception GetNonStaticEventError(IBindingMethod method);
         Exception GetObsoleteStepError(BindingObsoletion bindingObsoletion);
         Exception GetInvalidStepDefinitionError(IStepDefinitionBinding stepDefinitionBinding);
+        Exception GetInvalidBindingRegistryError(IEnumerable<string> getErrorMessages);
     }
 
     internal class ErrorProvider : IErrorProvider
@@ -116,11 +116,6 @@ namespace TechTalk.SpecFlow.ErrorHandling
             return new BindingException($"Binding methods with more than {maxParam} parameters are not supported");
         }
 
-        public Exception GetNonStaticEventError(IBindingMethod method)
-        {
-            throw new BindingException($"The binding methods for before/after feature and before/after test run events must be static! {GetMethodText(method)}");
-        }
-
         public Exception GetObsoleteStepError(BindingObsoletion bindingObsoletion)
         {
             throw new BindingException(bindingObsoletion.Message);
@@ -133,6 +128,11 @@ namespace TechTalk.SpecFlow.ErrorHandling
                 $"{Environment.NewLine}If this error comes after upgrading to SpecFlow v4, check the upgrade guide: https://docs.specflow.org/projects/specflow/en/latest/Guides/UpgradeSpecFlow3To4.html" :
                 "";
             return new BindingException($"Invalid step definition! The step definition method '{GetMethodText(stepDefinitionBinding.Method)}' is invalid: {stepDefinitionBinding.ErrorMessage}.{upgradeMessage}");
+        }
+
+        public Exception GetInvalidBindingRegistryError(IEnumerable<string> errorMessages)
+        {
+            throw new BindingException("Binding error(s) found: " + Environment.NewLine + string.Join(Environment.NewLine, errorMessages));
         }
     }
 }

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -23,7 +23,7 @@ namespace TechTalk.SpecFlow.ErrorHandling
         Exception GetTooManyBindingParamError(int maxParam);
         Exception GetObsoleteStepError(BindingObsoletion bindingObsoletion);
         Exception GetInvalidStepDefinitionError(IStepDefinitionBinding stepDefinitionBinding);
-        Exception GetInvalidBindingRegistryError(IEnumerable<(BindingErrorType ErrorType, string Message)> errors);
+        Exception GetInvalidBindingRegistryError(IEnumerable<BindingError> errors);
     }
 
     internal class ErrorProvider : IErrorProvider
@@ -130,7 +130,7 @@ namespace TechTalk.SpecFlow.ErrorHandling
             return new BindingException($"Invalid step definition! The step definition method '{GetMethodText(stepDefinitionBinding.Method)}' is invalid: {stepDefinitionBinding.ErrorMessage}.{upgradeMessage}");
         }
 
-        public Exception GetInvalidBindingRegistryError(IEnumerable<(BindingErrorType ErrorType, string Message)> errors)
+        public Exception GetInvalidBindingRegistryError(IEnumerable<BindingError> errors)
         {
             throw new BindingException("Binding error(s) found: " + Environment.NewLine + string.Join(Environment.NewLine, errors.Select(e => e.Message)));
         }

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -23,7 +23,7 @@ namespace TechTalk.SpecFlow.ErrorHandling
         Exception GetTooManyBindingParamError(int maxParam);
         Exception GetObsoleteStepError(BindingObsoletion bindingObsoletion);
         Exception GetInvalidStepDefinitionError(IStepDefinitionBinding stepDefinitionBinding);
-        Exception GetInvalidBindingRegistryError(IEnumerable<string> getErrorMessages);
+        Exception GetInvalidBindingRegistryError(IEnumerable<(BindingErrorType ErrorType, string Message)> errors);
     }
 
     internal class ErrorProvider : IErrorProvider
@@ -130,9 +130,9 @@ namespace TechTalk.SpecFlow.ErrorHandling
             return new BindingException($"Invalid step definition! The step definition method '{GetMethodText(stepDefinitionBinding.Method)}' is invalid: {stepDefinitionBinding.ErrorMessage}.{upgradeMessage}");
         }
 
-        public Exception GetInvalidBindingRegistryError(IEnumerable<string> errorMessages)
+        public Exception GetInvalidBindingRegistryError(IEnumerable<(BindingErrorType ErrorType, string Message)> errors)
         {
-            throw new BindingException("Binding error(s) found: " + Environment.NewLine + string.Join(Environment.NewLine, errorMessages));
+            throw new BindingException("Binding error(s) found: " + Environment.NewLine + string.Join(Environment.NewLine, errors.Select(e => e.Message)));
         }
     }
 }

--- a/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
+++ b/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
@@ -139,7 +139,7 @@ namespace TechTalk.SpecFlow.Infrastructure
         protected virtual StepDefinitionAmbiguityReason OnNoMatch(StepInstance stepInstance, CultureInfo bindingCulture, out List<BindingMatch> matches)
         {
             /*
-            //HACK: since out param matching does not support agrument converters yet, we rather show more results than "no match"
+            //HACK: since out param matching does not support argument converters yet, we rather show more results than "no match"
             matches = GetCandidatingBindings(stepInstance, useParamMatching: false).ToList();
              */
 
@@ -162,19 +162,19 @@ namespace TechTalk.SpecFlow.Infrastructure
 
             if (matchesWithoutParamCheck.Count == 1)
             {
-                // no ambiguouity, but param error -> execute will find it out
+                // no ambiguity, but param error -> execute will find it out
                 return StepDefinitionAmbiguityReason.None;
             }
-            if (matchesWithoutParamCheck.Count > 1) // ambiguouity, because of param error
+            if (matchesWithoutParamCheck.Count > 1) // ambiguity, because of param error
                 return StepDefinitionAmbiguityReason.ParameterErrors;
 
-            return StepDefinitionAmbiguityReason.None; // no ambiguouity: simple missing step definition
+            return StepDefinitionAmbiguityReason.None; // no ambiguity: simple missing step definition
         }
 
         protected IEnumerable<BindingMatch> GetCandidatingBindings(StepInstance stepInstance, CultureInfo bindingCulture, bool useRegexMatching = true, bool useParamMatching = true, bool useScopeMatching = true)
         {
             var matches = _bindingRegistry.GetConsideredStepDefinitions(stepInstance.StepDefinitionType, stepInstance.Text).Select(b => Match(b, stepInstance, bindingCulture, useRegexMatching, useParamMatching, useScopeMatching)).Where(b => b.Success);
-            // we remove duplicate maches for the same method (take the highest scope matches from each)
+            // we remove duplicate matches for the same method (take the highest scope matches from each)
             matches = matches.GroupBy(m => m.StepBinding.Method, (_, methodMatches) => methodMatches.OrderByDescending(m => m.ScopeMatches).First(), BindingMethodComparer.Instance);
             return matches;
         }

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -539,6 +539,9 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         protected virtual BindingMatch GetStepMatch(StepInstance stepInstance)
         {
+            if (!_bindingRegistry.IsValid)
+                throw _errorProvider.GetInvalidBindingRegistryError(_bindingRegistry.GetErrorMessages());
+
             var match = _stepDefinitionMatchService.GetBestMatch(stepInstance, FeatureContext.BindingCulture, out var ambiguityReason, out var candidatingMatches);
 
             if (match.Success)
@@ -549,7 +552,7 @@ namespace TechTalk.SpecFlow.Infrastructure
                 if (ambiguityReason == StepDefinitionAmbiguityReason.AmbiguousSteps)
                     throw _errorProvider.GetAmbiguousMatchError(candidatingMatches, stepInstance);
 
-                if (ambiguityReason == StepDefinitionAmbiguityReason.ParameterErrors) // ambiguouity, because of param error
+                if (ambiguityReason == StepDefinitionAmbiguityReason.ParameterErrors) // ambiguity, because of param error
                     throw _errorProvider.GetAmbiguousBecauseParamCheckMatchError(candidatingMatches, stepInstance);
             }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSourceProcessorStub.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/BindingSourceProcessorStub.cs
@@ -43,5 +43,10 @@ namespace TechTalk.SpecFlow.RuntimeTests
             else
                 BindingSpecificErrorMessages.AddRange(validationResult.ErrorMessages);
         }
+
+        public void RegisterTypeLoadError(string errorMessage)
+        {
+            GeneralErrorMessages.Add(errorMessage);
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/Discovery/BindingSourceProcessorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/Discovery/BindingSourceProcessorTests.cs
@@ -35,7 +35,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings.Discovery
             };
 
             //ACT
-            sut.ProcessType(bindingSourceType);
+            sut.ProcessType(bindingSourceType).Should().BeTrue();
             sut.ProcessMethod(bindingSourceMethod);
             sut.BuildingCompleted();
 
@@ -50,6 +50,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings.Discovery
         {
             var bindingSourceType = new BindingSourceType
             {
+                IsClass = true,
                 Attributes = new[]
                 {
                     CreateBindingSourceAttribute("BindingAttribute", "TechTalk.SpecFlow.BindingAttribute")
@@ -80,13 +81,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings.Discovery
         [Binding]
         class StepDefClassWithAsyncVoid
         {
-            public static bool WasInvokedAsyncVoidStepDef = false;
-
             [Given("an authenticated user")]
             public async void AsyncVoidStepDef()
             {
                 await Task.Delay(50); // we need to wait a bit otherwise the assertion passes even if the method is called sync
-                WasInvokedAsyncVoidStepDef = true;
             }
         }
 
@@ -98,7 +96,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings.Discovery
             var bindingSourceMethod = CreateBindingSourceMethod(typeof(StepDefClassWithAsyncVoid), nameof(StepDefClassWithAsyncVoid.AsyncVoidStepDef),
                 CreateBindingSourceAttribute("GivenAttribute", "TechTalk.SpecFlow.GivenAttribute").WithValue("an authenticated user"));
 
-            sut.ProcessType(CreateDummyBindingSourceType());
+            sut.ProcessType(CreateDummyBindingSourceType()).Should().BeTrue();
             sut.ProcessMethod(bindingSourceMethod);
             sut.BuildingCompleted();
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -263,7 +263,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             var errorProvider = CreateErrorProvider();
 
-            Assert.Throws<BindingException>(() => errorProvider.GetInvalidBindingRegistryError(new[] { (BindingErrorType.BindingError, "error1"), (BindingErrorType.BindingError, "error2") }));
+            Assert.Throws<BindingException>(() => errorProvider.GetInvalidBindingRegistryError(new[] { new BindingError(BindingErrorType.BindingError, "error1"), new BindingError(BindingErrorType.BindingError, "error2") }));
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -259,18 +259,11 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Fact]
-        public void GetNonStaticEventError_Throws_BindingException_with_message_containing_full_assembly_name_method_name_and_parameters_types()
+        public void GetInvalidBindingRegistryError_Throws_BindingException_with_message_containing_all_errors()
         {
-            const string methodName = "WhenIAdd";
-            const string methodBindingTypeName = "CalculatorSteps";
-            const string methodBindingTypeFullName = "StepsAssembly1.CalculatorSteps";
-            const string parameter1Type = "Int32";
-
             var errorProvider = CreateErrorProvider();
 
-            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, parameter1Type);
-
-            Assert.Throws<BindingException>(() => errorProvider.GetNonStaticEventError(bindingMethod));
+            Assert.Throws<BindingException>(() => errorProvider.GetInvalidBindingRegistryError(new []{ "error1", "error2"}));
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -263,7 +263,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             var errorProvider = CreateErrorProvider();
 
-            Assert.Throws<BindingException>(() => errorProvider.GetInvalidBindingRegistryError(new []{ "error1", "error2"}));
+            Assert.Throws<BindingException>(() => errorProvider.GetInvalidBindingRegistryError(new[] { (BindingErrorType.BindingError, "error1"), (BindingErrorType.BindingError, "error2") }));
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -127,6 +127,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             bindingRegistryStub.Setup(br => br.GetHooks(HookType.AfterScenario)).Returns(afterScenarioEvents);
             
             bindingRegistryStub.Setup(br => br.GetStepTransformations()).Returns(stepTransformations);
+            bindingRegistryStub.Setup(br => br.IsValid).Returns(true);
 
             specFlowConfiguration = ConfigurationLoader.GetDefault();
             errorProviderStub = new Mock<IErrorProvider>();

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ Features:
 + Support Rule tags (can be used for hook filters, scoping and access through 'ScenarioInfo.CombinedTags')
 + Support for async step argument transformations. Fixes #2230
 + Support for ValueTask and ValueTask<T> binding methods (step definitions, hooks, step argument transformations)
++ Collect binding errors (type load, binding, step definition) and report them as exception when any of the tests are executed.
 
 Changes:
 + Existing step definition expressions detected to be either regular or cucumber expression. Check https://docs.specflow.org/projects/specflow/en/latest/Guides/UpgradeSpecFlow3To4.html for potential upgrade issues.


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->

Some generic binding errors (e.g. `[Binding]` on a generic type) were not properly reported as errors so far, only as warnings, but those are usually not visible by test runners. Some of these errors were causing strange exceptions during execution, but it was hard to trace them back to the source problem.

Also type load exceptions blocked the discovery process that causes problems with tooling (e.g. VS) that uses the binding registry builder to discover the step definitions.

This PR introduces validity of loaded binding registry and provides a way to query these errors from the binding registry. During test execution, the invalid binding registry fails the tests by listing all collected error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
