### PR TITLE
Clarify that `Task` is a valid return type in Step

### DIFF
--- a/docs/Bindings/Step-Definitions.md
+++ b/docs/Bindings/Step-Definitions.md
@@ -78,7 +78,7 @@ public void GivenStuffIsDone()
 * Must be a public method.
 * Can be either a static or an instance method. If it is an instance method, the containing class will be instantiated once for every scenario.
 * Cannot have `out` or `ref` parameters.
-* Shouldn't have a return type or have `Task` as return type.
+* Should return `void` or `Task`.
 
 ## Step Matching Styles & Rules
 


### PR DESCRIPTION
The sentence "Shouldn't have a return type or have `Task` as return type." can be read in two ways:
1. Should not have a return type nor return `Task`
2. Should not have a return type OR should return `Task`

So a minor change to make it more clear and direct.

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
