### PR TITLE
External data plugin, support for JSON files

### DIFF
--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/JsonLoaderTests.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/JsonLoaderTests.cs
@@ -71,11 +71,10 @@ namespace SpecFlow.ExternalData.SpecFlowPlugin.UnitTests
             Assert.True(worksheetResult.IsDataTable);
             Assert.Equal(3, worksheetResult.AsDataTable.Items.Count);
             var firstItem = worksheetResult.AsDataTable.Items[0];
-            Assert.Equal(4, firstItem.Fields.Count);
+            Assert.Equal(3, firstItem.Fields.Count);
             Assert.Equal("Chocolate", firstItem.Fields["product"].AsString());
-            Assert.Equal("2.5", firstItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
             Assert.Equal("brown", firstItem.Fields["color"].AsString());
-            Assert.Equal("[\r\n  {\r\n    \"name\": \"sugar\",\r\n    \"value\": \"150mg\"\r\n  },\r\n  {\r\n    \"name\": \"cacao\",\r\n    \"value\": \"50mg\"\r\n  }\r\n]", firstItem.Fields["ingredients"].AsString());
+            Assert.Equal("[\r\n  {\r\n    \"name\": \"Dark Chocolate\",\r\n    \"price\": \"1.6\"\r\n  },\r\n  {\r\n    \"name\": \"Milk Chocolate\",\r\n    \"price\": \"1.55\"\r\n  }\r\n]", firstItem.Fields["varieties"].AsString());
         }
 
         [Fact]
@@ -86,25 +85,23 @@ namespace SpecFlow.ExternalData.SpecFlowPlugin.UnitTests
 
             Assert.NotNull(result);
             Assert.True(result.IsDataRecord);
-            Assert.True(result.AsDataRecord.Fields.ContainsKey("products.ingredients"));
-            var worksheetResult = result.AsDataRecord.Fields["products.ingredients"];
+            Assert.True(result.AsDataRecord.Fields.ContainsKey("products.varieties"));
+            var worksheetResult = result.AsDataRecord.Fields["products.varieties"];
             Assert.True(worksheetResult.IsDataTable);
-            Assert.Equal(4, worksheetResult.AsDataTable.Items.Count);
+            Assert.Equal(6, worksheetResult.AsDataTable.Items.Count);
             var firstItem = worksheetResult.AsDataTable.Items.First();
-            Assert.Equal(5, firstItem.Fields.Count);
+            Assert.Equal(4, firstItem.Fields.Count);
             Assert.Equal("Chocolate", firstItem.Fields["product"].AsString());
-            Assert.Equal("2.5", firstItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
             Assert.Equal("brown", firstItem.Fields["color"].AsString());
-            Assert.Equal("sugar", firstItem.Fields["name"].AsString());
-            Assert.Equal("150mg", firstItem.Fields["value"].AsString());
+            Assert.Equal("1.6", firstItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
+            Assert.Equal("Dark Chocolate", firstItem.Fields["name"].AsString());
             
             var lastItem = worksheetResult.AsDataTable.Items.Last();
-            Assert.Equal(5, lastItem.Fields.Count);
+            Assert.Equal(4, lastItem.Fields.Count);
             Assert.Equal("Orange", lastItem.Fields["product"].AsString());
-            Assert.Equal("1.2", lastItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
             Assert.Equal("orange", lastItem.Fields["color"].AsString());
-            Assert.Equal("sugar", lastItem.Fields["name"].AsString());
-            Assert.Equal("50mg", lastItem.Fields["value"].AsString());
+            Assert.Equal("1.6", lastItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
+            Assert.Equal("Tangerine", lastItem.Fields["name"].AsString());
         }
     }
 }

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/JsonLoaderTests.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/JsonLoaderTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using SpecFlow.ExternalData.SpecFlowPlugin.Loaders;
+using Xunit;
+
+namespace SpecFlow.ExternalData.SpecFlowPlugin.UnitTests
+{
+    public class JsonLoaderTests
+    {
+        private static readonly string SampleFilesFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".", "SampleFiles");
+        private string _productsSampleFilePath = Path.Combine(SampleFilesFolder, "products.json");
+        private string _nestedProductsSampleFilePath = Path.Combine(SampleFilesFolder, "products-nested-dataset.json");
+
+        private string SampleFeatureFilePathInSampleFileFolder =>
+            Path.Combine(Path.GetDirectoryName(_productsSampleFilePath) ?? ".", "Sample.feature");
+
+        private JsonLoader CreateSut() => new();
+
+        [Fact]
+        public void Can_read_simple_json_file()
+        {
+            var sut = CreateSut();
+            var result = sut.LoadDataSource(_productsSampleFilePath, null);
+            
+            Assert.NotNull(result);
+            Assert.True(result.IsDataRecord);
+            Assert.True(result.AsDataRecord.Fields.ContainsKey("products"));
+            var worksheetResult = result.AsDataRecord.Fields["products"];
+            Assert.True(worksheetResult.IsDataTable);
+            Assert.Equal(3, worksheetResult.AsDataTable.Items.Count);
+            Assert.Equal("Chocolate", worksheetResult.AsDataTable.Items[0].Fields["product"].AsString());
+            Assert.Equal("2.5", worksheetResult.AsDataTable.Items[0].Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
+            Assert.Equal("brown", worksheetResult.AsDataTable.Items[0].Fields["color"].AsString());
+        }
+
+        [Fact]
+        public void Can_handle_relative_path()
+        {
+            var sut = CreateSut();
+            var result = sut.LoadDataSource(
+                Path.GetFileName(_productsSampleFilePath), 
+                SampleFeatureFilePathInSampleFileFolder);
+
+            Assert.True(result.IsDataRecord);
+        }
+
+        
+        [Fact]
+        public void Returns_name_of_first_object_array_as_default_data_set()
+        {
+            var sut = CreateSut();
+            var result = sut.LoadDataSource(_productsSampleFilePath, null);
+
+            Assert.NotNull(result);
+            Assert.Equal("products", result.DefaultDataSet);
+        }
+
+        [Fact]
+        public void Can_read_products_from_json_with_nested_dataset()
+        {
+            var sut = CreateSut();
+            var result = sut.LoadDataSource(_nestedProductsSampleFilePath, null);
+
+            Assert.NotNull(result);
+            Assert.True(result.IsDataRecord);
+            Assert.True(result.AsDataRecord.Fields.ContainsKey("products"));
+            var worksheetResult = result.AsDataRecord.Fields["products"];
+            Assert.True(worksheetResult.IsDataTable);
+            Assert.Equal(3, worksheetResult.AsDataTable.Items.Count);
+            var firstItem = worksheetResult.AsDataTable.Items[0];
+            Assert.Equal(4, firstItem.Fields.Count);
+            Assert.Equal("Chocolate", firstItem.Fields["product"].AsString());
+            Assert.Equal("2.5", firstItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
+            Assert.Equal("brown", firstItem.Fields["color"].AsString());
+            Assert.Equal("[\r\n  {\r\n    \"name\": \"sugar\",\r\n    \"value\": \"150mg\"\r\n  },\r\n  {\r\n    \"name\": \"cacao\",\r\n    \"value\": \"50mg\"\r\n  }\r\n]", firstItem.Fields["ingredients"].AsString());
+        }
+
+        [Fact]
+        public void Reads_nested_dataset()
+        {
+            var sut = CreateSut();
+            var result = sut.LoadDataSource(_nestedProductsSampleFilePath, null);
+
+            Assert.NotNull(result);
+            Assert.True(result.IsDataRecord);
+            Assert.True(result.AsDataRecord.Fields.ContainsKey("products.ingredients"));
+            var worksheetResult = result.AsDataRecord.Fields["products.ingredients"];
+            Assert.True(worksheetResult.IsDataTable);
+            Assert.Equal(4, worksheetResult.AsDataTable.Items.Count);
+            var firstItem = worksheetResult.AsDataTable.Items.First();
+            Assert.Equal(5, firstItem.Fields.Count);
+            Assert.Equal("Chocolate", firstItem.Fields["product"].AsString());
+            Assert.Equal("2.5", firstItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
+            Assert.Equal("brown", firstItem.Fields["color"].AsString());
+            Assert.Equal("sugar", firstItem.Fields["name"].AsString());
+            Assert.Equal("150mg", firstItem.Fields["value"].AsString());
+            
+            var lastItem = worksheetResult.AsDataTable.Items.Last();
+            Assert.Equal(5, lastItem.Fields.Count);
+            Assert.Equal("Orange", lastItem.Fields["product"].AsString());
+            Assert.Equal("1.2", lastItem.Fields["price"].AsString(CultureInfo.GetCultureInfo("en-us")));
+            Assert.Equal("orange", lastItem.Fields["color"].AsString());
+            Assert.Equal("sugar", lastItem.Fields["name"].AsString());
+            Assert.Equal("50mg", lastItem.Fields["value"].AsString());
+        }
+    }
+}

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products-nested-dataset.json
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products-nested-dataset.json
@@ -1,0 +1,45 @@
+﻿{
+    "products":
+    [
+        {
+           "product": "Chocolate",
+            "price": "2.5",
+            "color": "brown",
+            "ingredients":
+            [
+                {
+                    "name": "sugar",
+                    "value": "150mg"
+                },
+                {
+                    "name": "cacao",
+                    "value": "50mg"
+                }
+            ]
+        },
+        {
+          "product": "Apple",
+          "price": "1.0",
+          "color": "red",
+           "ingredients":
+            [
+                {
+                    "name": "sugar",
+                    "value": "70mg"
+                }
+            ]
+        },
+        {
+          "product": "Orange",
+          "price": "1.2",
+          "color": "orange",
+          "ingredients":
+            [
+                {
+                    "name": "sugar",
+                    "value": "50mg"
+                }
+            ]
+        }
+    ]
+}

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products-nested-dataset.json
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products-nested-dataset.json
@@ -2,44 +2,49 @@
     "products":
     [
         {
-           "product": "Chocolate",
-            "price": "2.5",
+            "product": "Chocolate",
             "color": "brown",
-            "ingredients":
+            "varieties":
             [
                 {
-                    "name": "sugar",
-                    "value": "150mg"
+                    "name": "Dark Chocolate",
+                    "price": "1.6"
                 },
                 {
-                    "name": "cacao",
-                    "value": "50mg"
+                    "name": "Milk Chocolate",
+                    "price": "1.55"
                 }
             ]
         },
         {
-          "product": "Apple",
-          "price": "1.0",
-          "color": "red",
-           "ingredients":
+           "product": "Apple",
+           "color": "red",
+           "varieties":
             [
                 {
-                    "name": "sugar",
-                    "value": "70mg"
+                    "name": "Pink Lady",
+                    "price": "1.0"
+                },
+                {
+                    "name": "Fuji",
+                    "price": "1.5"
                 }
-            ]
+           ]
         },
         {
           "product": "Orange",
-          "price": "1.2",
           "color": "orange",
-          "ingredients":
+          "varieties":
             [
                 {
-                    "name": "sugar",
-                    "value": "50mg"
+                    "name": "Seville Orange",
+                    "price": "1.3"
+                },
+                {
+                    "name": "Tangerine",
+                    "price": "1.6"
                 }
-            ]
+           ]
         }
     ]
 }

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products-nested-dataset.json
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products-nested-dataset.json
@@ -17,9 +17,9 @@
             ]
         },
         {
-           "product": "Apple",
-           "color": "red",
-           "varieties":
+            "product": "Apple",
+            "color": "red",
+            "varieties":
             [
                 {
                     "name": "Pink Lady",
@@ -32,9 +32,9 @@
            ]
         },
         {
-          "product": "Orange",
-          "color": "orange",
-          "varieties":
+            "product": "Orange",
+            "color": "orange",
+            "varieties":
             [
                 {
                     "name": "Seville Orange",

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products.json
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SampleFiles/products.json
@@ -1,0 +1,20 @@
+﻿{
+    "products":
+    [
+        {
+            "product": "Chocolate",
+            "price": "2.5",
+            "color": "brown"
+        },
+        {
+            "product": "Apple",
+            "price": "1.0",
+            "color": "red"
+        },
+        {
+            "product": "Orange",
+            "price": "1.2",
+            "color": "orange"
+        }
+    ]
+}

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests.csproj
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests/SpecFlow.ExternalData.SpecFlowPlugin.UnitTests.csproj
@@ -24,6 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="SampleFiles\products-nested-dataset.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="SampleFiles\products-special.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -37,6 +40,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="SampleFiles\products.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="SampleFiles\products.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="SampleFiles\products.xlsx">

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/ExternalDataGeneratorPlugin.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/ExternalDataGeneratorPlugin.cs
@@ -23,6 +23,7 @@ namespace SpecFlow.ExternalData.SpecFlowPlugin
                 args.ObjectContainer.RegisterTypeAs<DataSourceLoaderFactory, IDataSourceLoaderFactory>();
                 args.ObjectContainer.RegisterTypeAs<CsvLoader, IDataSourceLoader>("CSV");
                 args.ObjectContainer.RegisterTypeAs<ExcelLoader, IDataSourceLoader>("Excel");
+                args.ObjectContainer.RegisterTypeAs<JsonLoader, IDataSourceLoader>("JSON");
             };
         }
     }

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonDataTableGenerator.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonDataTableGenerator.cs
@@ -3,103 +3,102 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using SpecFlow.ExternalData.SpecFlowPlugin.DataSources;
 
-namespace SpecFlow.ExternalData.SpecFlowPlugin.Loaders;
-
-public class JsonDataTableGenerator
+namespace SpecFlow.ExternalData.SpecFlowPlugin.Loaders
 {
-    public DataTable FlattenDataSetToDataTable(JObject originalJson, string[] objectPath)
+
+    public class JsonDataTableGenerator
     {
-        try
+        public DataTable FlattenDataSetToDataTable(JObject originalJson, string[] objectPath)
         {
-            var header = GenerateHeader(originalJson, objectPath);
-            var dataTable = new DataTable(header.ToArray());
-            var records = GenerateRecordsFromNestedObjects(originalJson, objectPath, new List<DataRecord>());
-            foreach (var record in records)
-                dataTable.Items.Add(record);
+            try
+            {
+                var header = GenerateHeader(originalJson, objectPath);
+                var dataTable = new DataTable(header.ToArray());
+                var records = GenerateRecordsFromNestedObjects(originalJson, objectPath, new List<DataRecord>());
+                foreach (var record in records) dataTable.Items.Add(record);
 
-            return dataTable;
-        }
-        catch (System.NullReferenceException)
-        {
-            throw new ExternalDataPluginException($"Unable to flatten {objectPath} into DataTable");
-        }
-    }
-
-    private static List<string> GenerateHeader(JObject originalJson, string[] objectPath)
-    {
-        var currentObject = originalJson;
-      
-        List<string> header = new();
-        while (objectPath.Length > 0)
-        {
-            var currentObjectArray = currentObject[objectPath.First()]?.ToObject<JArray>();
-
-            if(currentObjectArray == null)
-                throw new ExternalDataPluginException($"Expected {objectPath.First()} to be in json object");
-
-            objectPath = objectPath.Skip(1).ToArray();
-        
-            if(currentObjectArray.First == null)
-                throw new ExternalDataPluginException("Empty object arrays are not supported");
-
-            currentObject = currentObjectArray.First.ToObject<JObject>();
-            header.AddRange(GetPropertiesExcludingToBeFlattenedArrayObject(currentObject, objectPath).Select(p => p.Name));
+                return dataTable;
+            }
+            catch (System.NullReferenceException)
+            {
+                throw new ExternalDataPluginException($"Unable to flatten {objectPath} into DataTable");
+            }
         }
 
-        return header;
-    }
-
-    private List<DataRecord> GenerateRecordsFromNestedObjects(JObject currentObject, string[] dataSetObjectPath,
-        List<DataRecord> currentRecords)
-    {
-        if (dataSetObjectPath.Length == 0)
-            return currentRecords;
-
-        var objectArrayPropertyName = dataSetObjectPath.First();
-        var remainingObjectArrays = dataSetObjectPath.Skip(1).ToArray();
-
-        var objectArray = currentObject[objectArrayPropertyName]?.ToObject<JArray>();
-        if (objectArray == null) 
-            throw new ExternalDataPluginException($"Expected object array property {objectArrayPropertyName} inside {currentObject}");
-        
-        var result = new List<DataRecord>();
-        foreach (var jObject in objectArray.Select(i => i.ToObject<JObject>()))
+        private static List<string> GenerateHeader(JObject originalJson, string[] objectPath)
         {
-            
-            var objectProperties = GetPropertiesExcludingToBeFlattenedArrayObject(jObject, remainingObjectArrays);
+            var currentObject = originalJson;
 
-            var objectRecord = new DataRecord();
-            foreach (var property in objectProperties)
-                objectRecord.Fields[property.Name] = new DataValue(property.Value);
+            List<string> header = new();
+            while (objectPath.Length > 0)
+            {
+                var currentObjectArray = currentObject[objectPath.First()]?.ToObject<JArray>();
 
-            List<DataRecord> intermediateResult;
-            if (currentRecords.Any())
-                intermediateResult = AppendFieldsToCurrentDataRecords(currentRecords, objectRecord);
-            else
-                intermediateResult = new List<DataRecord> { objectRecord };
+                if (currentObjectArray == null) throw new ExternalDataPluginException($"Expected {objectPath.First()} to be in json object");
 
-            result.AddRange(GenerateRecordsFromNestedObjects(jObject, remainingObjectArrays, intermediateResult));
+                objectPath = objectPath.Skip(1).ToArray();
+
+                if (currentObjectArray.First == null) throw new ExternalDataPluginException("Empty object arrays are not supported");
+
+                currentObject = currentObjectArray.First.ToObject<JObject>();
+                header.AddRange(GetPropertiesExcludingToBeFlattenedArrayObject(currentObject, objectPath).Select(p => p.Name));
+            }
+
+            return header;
         }
 
-        return result;
-    }
-
-    private static List<DataRecord> AppendFieldsToCurrentDataRecords(List<DataRecord> currentRecords, DataRecord objectRecord)
-    {
-        var result = new List<DataRecord>();
-        foreach (var record in currentRecords)
+        private List<DataRecord> GenerateRecordsFromNestedObjects(
+            JObject currentObject,
+            string[] dataSetObjectPath,
+            List<DataRecord> currentRecords)
         {
-            var updatedRecord = new DataRecord(record.Fields);
-            objectRecord.Fields.ToList().ForEach(x => updatedRecord.Fields.Add(x.Key, x.Value));
-            result.Add(updatedRecord);
+            if (dataSetObjectPath.Length == 0) return currentRecords;
+
+            var objectArrayPropertyName = dataSetObjectPath.First();
+            var remainingObjectArrays = dataSetObjectPath.Skip(1).ToArray();
+
+            var objectArray = currentObject[objectArrayPropertyName]?.ToObject<JArray>();
+            if (objectArray == null) throw new ExternalDataPluginException($"Expected object array property {objectArrayPropertyName} inside {currentObject}");
+
+            var result = new List<DataRecord>();
+            foreach (var jObject in objectArray.Select(i => i.ToObject<JObject>()))
+            {
+
+                var objectProperties = GetPropertiesExcludingToBeFlattenedArrayObject(jObject, remainingObjectArrays);
+
+                var objectRecord = new DataRecord();
+                foreach (var property in objectProperties) objectRecord.Fields[property.Name] = new DataValue(property.Value);
+
+                List<DataRecord> intermediateResult;
+                if (currentRecords.Any())
+                    intermediateResult = AppendFieldsToCurrentDataRecords(currentRecords, objectRecord);
+                else
+                    intermediateResult = new List<DataRecord> { objectRecord };
+
+                result.AddRange(GenerateRecordsFromNestedObjects(jObject, remainingObjectArrays, intermediateResult));
+            }
+
+            return result;
         }
 
-        return result;
-    }
-    
-    private static List<JProperty> GetPropertiesExcludingToBeFlattenedArrayObject(JObject childJson,
-        string[] remainingDataSets)
-    {
-        return childJson.Properties().Where(p => p.Name != remainingDataSets.FirstOrDefault()).ToList();
+        private static List<DataRecord> AppendFieldsToCurrentDataRecords(List<DataRecord> currentRecords, DataRecord objectRecord)
+        {
+            var result = new List<DataRecord>();
+            foreach (var record in currentRecords)
+            {
+                var updatedRecord = new DataRecord(record.Fields);
+                objectRecord.Fields.ToList().ForEach(x => updatedRecord.Fields.Add(x.Key, x.Value));
+                result.Add(updatedRecord);
+            }
+
+            return result;
+        }
+
+        private static List<JProperty> GetPropertiesExcludingToBeFlattenedArrayObject(
+            JObject childJson,
+            string[] remainingDataSets)
+        {
+            return childJson.Properties().Where(p => p.Name != remainingDataSets.FirstOrDefault()).ToList();
+        }
     }
 }

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonDataTableGenerator.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonDataTableGenerator.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using SpecFlow.ExternalData.SpecFlowPlugin.DataSources;
+
+namespace SpecFlow.ExternalData.SpecFlowPlugin.Loaders;
+
+public class JsonDataTableGenerator
+{
+    public DataTable FlattenDataSetToDataTable(JObject originalJson, string[] objectPath)
+    {
+        try
+        {
+            var header = GenerateHeader(originalJson, objectPath);
+
+            var dataTable = new DataTable(header.ToArray());
+            var records = GenerateRecordsFromNestedObjects(originalJson, objectPath, new List<DataRecord>());
+            foreach (var record in records)
+                dataTable.Items.Add(record);
+
+            return dataTable;
+        }
+        catch (System.NullReferenceException)
+        {
+            throw new ExternalDataPluginException($"Unable to flatten {objectPath} into DataTable");
+        }
+    }
+
+    private List<DataRecord> GenerateRecordsFromNestedObjects(JObject currentObject, string[] objectPath,
+        List<DataRecord> currentRecords)
+    {
+        if (objectPath.Length == 0)
+            return currentRecords;
+
+        if (currentObject[objectPath.First()] == null) 
+            return currentRecords;
+
+        var objectArray = currentObject[objectPath.First()].ToObject<JArray>();
+        var remainingObjects = objectPath.Skip(1).ToArray();
+
+        var result = new List<DataRecord>();
+        foreach (var jObject in objectArray.Select(i => i.ToObject<JObject>()))
+        {
+            var intermediateResult = new List<DataRecord>();
+            var objectProperties = GetPropertiesExcludingNestedArrayObjects(jObject, remainingObjects);
+
+            var objectRecord = new DataRecord();
+            foreach (var property in objectProperties)
+                objectRecord.Fields[property.Name] = new DataValue(property.Value);
+
+            if (currentRecords.Any())
+            {
+                foreach (var record in currentRecords)
+                {
+                    var updatedRecord = new DataRecord(record.Fields);
+                    objectRecord.Fields.ToList().ForEach(x => updatedRecord.Fields.Add(x.Key, x.Value));
+                    intermediateResult.Add(updatedRecord);
+                }
+            }
+            else
+                intermediateResult.Add(objectRecord);
+
+            result.AddRange(GenerateRecordsFromNestedObjects(jObject, remainingObjects, intermediateResult));
+        }
+
+        return result;
+    }
+
+    private static List<string> GenerateHeader(JObject originalJson, string[] objectPath)
+    {
+        var currentObject = originalJson;
+      
+        List<string> header = new();
+        while (objectPath.Length > 0)
+        {
+            var currentObjectArray = currentObject[objectPath.First()]?.ToObject<JArray>();
+
+            if(currentObjectArray == null)
+                throw new ExternalDataPluginException($"Expected {objectPath.First()} to be in json object");
+
+            objectPath = objectPath.Skip(1).ToArray();
+        
+            if(currentObjectArray.First == null)
+                throw new ExternalDataPluginException("Empty object arrays are not supported");
+
+            currentObject = currentObjectArray.First.ToObject<JObject>();
+            header.AddRange(GetPropertiesExcludingNestedArrayObjects(currentObject, objectPath).Select(p => p.Name));
+        }
+
+        return header;
+    }
+
+
+    private static List<JProperty> GetPropertiesExcludingNestedArrayObjects(JObject childJson,
+        string[] remainingDataSets)
+    {
+        return childJson.Properties().Where(p => p.Name != remainingDataSets.FirstOrDefault()).ToList();
+    }
+}

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonLoader.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonLoader.cs
@@ -4,74 +4,74 @@ using Newtonsoft.Json.Linq;
 using SpecFlow.ExternalData.SpecFlowPlugin.DataSources;
 using Newtonsoft.Json;
 
-namespace SpecFlow.ExternalData.SpecFlowPlugin.Loaders;
-
-public class JsonLoader : FileBasedLoader
+namespace SpecFlow.ExternalData.SpecFlowPlugin.Loaders
 {
-    public JsonLoader() : base("Json", ".json")
+
+    public class JsonLoader : FileBasedLoader
     {
-                
-    }
-
-    protected override DataSource LoadDataSourceFromFilePath(string filePath, string sourceFilePath)
-    {
-        var fileContent = ReadTextFileContent(filePath);
-
-        return LoadJsonDataSource(fileContent, sourceFilePath);
-    }
-
-    private List<string> DetermineDataSets(JObject jsonObject, string dataSetPrepend)
-    {
-        var dataSets = new HashSet<string>();
-        foreach (var array in GetArraysFromObject(jsonObject))
-        { 
-            var firstArrayObject = array.Children().First().ToObject<JObject>();
-            if (firstArrayObject == null)
-              throw new ExternalDataPluginException("Empty arrays are not supported, as they would lead to sparse scenario examples");
-
-            var dataSetPath = string.IsNullOrWhiteSpace(dataSetPrepend) ? array.Path : $"{dataSetPrepend}.{array.Path}";
-                
-            dataSets.Add(dataSetPath);
-
-            foreach (var nestedDataSetPath in DetermineDataSets(firstArrayObject, dataSetPath)) 
-                dataSets.Add(nestedDataSetPath); 
-        }
-
-        return dataSets.ToList();
-    }
-
-    private static IEnumerable<JToken> GetArraysFromObject(JObject jsonObject)
-    {
-        return jsonObject.Properties().Where(p => p.Value.Type == JTokenType.Array).Select(a => a.Value);
-    }
-
-    private DataSource LoadJsonDataSource(string fileContent, string sourceFilePath)
-    {
-        JObject fileJson = ParseJson(fileContent);
-        var dataSets = DetermineDataSets(fileJson, "");
-        var dataSetsRecord = new DataRecord();
-        var jsonDataTableGenerator = new JsonDataTableGenerator();
-        foreach (var dataSetPath in dataSets)
+        public JsonLoader() : base("Json", ".json")
         {
-            var dataTable = jsonDataTableGenerator.FlattenDataSetToDataTable(fileJson, dataSetPath.Split('.'));
-            dataSetsRecord.Fields[dataSetPath] = new DataValue(dataTable);
-        }
-            
-        return new DataSource(dataSetsRecord, dataSets.First());
-    }
 
-    private static JObject ParseJson(string fileContent)
-    {
-        JObject fileJson;
-        try
-        {
-            fileJson = JObject.Parse(fileContent);
-        }
-        catch (JsonReaderException jsonReaderException)
-        {
-            throw new ExternalDataPluginException($"Failed to parse json file: {jsonReaderException}");
         }
 
-        return fileJson;
+        protected override DataSource LoadDataSourceFromFilePath(string filePath, string sourceFilePath)
+        {
+            var fileContent = ReadTextFileContent(filePath);
+
+            return LoadJsonDataSource(fileContent, sourceFilePath);
+        }
+
+        private List<string> DetermineDataSets(JObject jsonObject, string dataSetPrepend)
+        {
+            var dataSets = new HashSet<string>();
+            foreach (var array in GetArraysFromObject(jsonObject))
+            {
+                var firstArrayObject = array.Children().First().ToObject<JObject>();
+                if (firstArrayObject == null) throw new ExternalDataPluginException("Empty arrays are not supported, as they would lead to sparse scenario examples");
+
+                var dataSetPath = string.IsNullOrWhiteSpace(dataSetPrepend) ? array.Path : $"{dataSetPrepend}.{array.Path}";
+
+                dataSets.Add(dataSetPath);
+
+                foreach (var nestedDataSetPath in DetermineDataSets(firstArrayObject, dataSetPath)) dataSets.Add(nestedDataSetPath);
+            }
+
+            return dataSets.ToList();
+        }
+
+        private static IEnumerable<JToken> GetArraysFromObject(JObject jsonObject)
+        {
+            return jsonObject.Properties().Where(p => p.Value.Type == JTokenType.Array).Select(a => a.Value);
+        }
+
+        private DataSource LoadJsonDataSource(string fileContent, string sourceFilePath)
+        {
+            JObject fileJson = ParseJson(fileContent);
+            var dataSets = DetermineDataSets(fileJson, "");
+            var dataSetsRecord = new DataRecord();
+            var jsonDataTableGenerator = new JsonDataTableGenerator();
+            foreach (var dataSetPath in dataSets)
+            {
+                var dataTable = jsonDataTableGenerator.FlattenDataSetToDataTable(fileJson, dataSetPath.Split('.'));
+                dataSetsRecord.Fields[dataSetPath] = new DataValue(dataTable);
+            }
+
+            return new DataSource(dataSetsRecord, dataSets.First());
+        }
+
+        private static JObject ParseJson(string fileContent)
+        {
+            JObject fileJson;
+            try
+            {
+                fileJson = JObject.Parse(fileContent);
+            }
+            catch (JsonReaderException jsonReaderException)
+            {
+                throw new ExternalDataPluginException($"Failed to parse json file: {jsonReaderException}");
+            }
+
+            return fileJson;
+        }
     }
 }

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonLoader.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonLoader.cs
@@ -1,0 +1,77 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using SpecFlow.ExternalData.SpecFlowPlugin.DataSources;
+using Newtonsoft.Json;
+
+namespace SpecFlow.ExternalData.SpecFlowPlugin.Loaders;
+
+public class JsonLoader : FileBasedLoader
+{
+    public JsonLoader() : base("Json", ".json")
+    {
+                
+    }
+
+    protected override DataSource LoadDataSourceFromFilePath(string filePath, string sourceFilePath)
+    {
+        var fileContent = ReadTextFileContent(filePath);
+
+        return LoadJsonDataSource(fileContent, sourceFilePath);
+    }
+
+    private List<string> DetermineDataSets(JObject jsonObject, string dataSetPrepend)
+    {
+        var dataSets = new HashSet<string>();
+        foreach (var array in GetArraysFromObject(jsonObject))
+        { 
+            var firstArrayObject = array.Children().First().ToObject<JObject>();
+            if (firstArrayObject == null)
+                continue;
+
+            var dataSetPath = string.IsNullOrWhiteSpace(dataSetPrepend) ? array.Path : $"{dataSetPrepend}.{array.Path}";
+                
+            dataSets.Add(dataSetPath);
+
+            foreach (var nestedDataSetPath in DetermineDataSets(firstArrayObject, dataSetPath)) 
+                dataSets.Add(nestedDataSetPath); 
+        }
+
+        return dataSets.ToList();
+    }
+
+    private static IEnumerable<JToken> GetArraysFromObject(JObject jsonObject)
+    {
+        return jsonObject.Properties().Where(p => p.Value.Type == JTokenType.Array).Select(a => a.Value);
+    }
+
+    private DataSource LoadJsonDataSource(string fileContent, string sourceFilePath)
+    {
+        JObject fileJson = ParseJson(fileContent);
+        var dataSets = DetermineDataSets(fileJson, "");
+        var dataSetsRecord = new DataRecord();
+        var nestedObjectsHelper = new JsonDataTableGenerator();
+        foreach (var dataSet in dataSets)
+        {
+            var dataTable = nestedObjectsHelper.FlattenDataSetToDataTable(fileJson, dataSet.Split('.'));
+            dataSetsRecord.Fields[dataSet] = new DataValue(dataTable);
+        }
+            
+        return new DataSource(dataSetsRecord, dataSets.First());
+    }
+
+    private static JObject ParseJson(string fileContent)
+    {
+        JObject fileJson;
+        try
+        {
+            fileJson = JObject.Parse(fileContent);
+        }
+        catch (JsonReaderException jsonReaderException)
+        {
+            throw new ExternalDataPluginException($"Failed to parse json file: {jsonReaderException}");
+        }
+
+        return fileJson;
+    }
+}

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonLoader.cs
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/Loaders/JsonLoader.cs
@@ -27,7 +27,7 @@ public class JsonLoader : FileBasedLoader
         { 
             var firstArrayObject = array.Children().First().ToObject<JObject>();
             if (firstArrayObject == null)
-                continue;
+              throw new ExternalDataPluginException("Empty arrays are not supported, as they would lead to sparse scenario examples");
 
             var dataSetPath = string.IsNullOrWhiteSpace(dataSetPrepend) ? array.Path : $"{dataSetPrepend}.{array.Path}";
                 
@@ -50,11 +50,11 @@ public class JsonLoader : FileBasedLoader
         JObject fileJson = ParseJson(fileContent);
         var dataSets = DetermineDataSets(fileJson, "");
         var dataSetsRecord = new DataRecord();
-        var nestedObjectsHelper = new JsonDataTableGenerator();
-        foreach (var dataSet in dataSets)
+        var jsonDataTableGenerator = new JsonDataTableGenerator();
+        foreach (var dataSetPath in dataSets)
         {
-            var dataTable = nestedObjectsHelper.FlattenDataSetToDataTable(fileJson, dataSet.Split('.'));
-            dataSetsRecord.Fields[dataSet] = new DataValue(dataTable);
+            var dataTable = jsonDataTableGenerator.FlattenDataSetToDataTable(fileJson, dataSetPath.Split('.'));
+            dataSetsRecord.Fields[dataSetPath] = new DataValue(dataTable);
         }
             
         return new DataSource(dataSetsRecord, dataSets.First());

--- a/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/SpecFlow.ExternalData.SpecFlowPlugin.csproj
+++ b/Plugins/SpecFlow.ExternalData/SpecFlow.ExternalData.SpecFlowPlugin/SpecFlow.ExternalData.SpecFlowPlugin.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     
     <PackageReference Include="CsvHelper" Version="27.2.1" />

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/ExternalDataFromJson.feature
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/ExternalDataFromJson.feature
@@ -1,0 +1,38 @@
+﻿Feature: External Data from Json file
+
+@DataSource:products.json
+Scenario: The basket price is calculated correctly
+	The scenario will be treated as a scenario outline with the examples from the json file.
+	The first object array is used by default from the json file.
+	Given the price of <product> is €<price>
+	And the customer has put 1 pcs of <product> to the basket
+	When the basket price is calculated
+	Then the basket price should be €<price>
+
+@DataSource:products.json @DataSet:other_products
+Scenario: The basket price is calculated correctly for other products
+	The scenario will be treated as a scenario outline with the examples from the Excel file.
+	The "other_products" sheet is used from the Excel file.
+	Given the price of <product> is €<price>
+	And the customer has put 1 pcs of <product> to the basket
+	When the basket price is calculated
+	Then the basket price should be €<price>
+
+
+@DataSource:products-nested-dataset.json
+Scenario: The basket price is calculated correctly for products in nested products json
+	The scenario will be treated as a scenario outline with the examples from the json file.
+	The first object array is used by default from the json file.
+	Given the price of <product> is €<price>
+	And the customer has put 1 pcs of <product> to the basket
+	When the basket price is calculated
+	Then the basket price should be €<price>
+
+@DataSource:products-nested-dataset.json @DataSet:products.ingredients
+Scenario: The basket price is calculated correctly for products.ingredients in nested products json
+	The scenario will be treated as a scenario outline with the examples from the json file.
+	The first object array is used by default from the json file.
+	Given the price of <product> is €<price>
+	And the customer has put 1 pcs of <product> to the basket
+	When the basket price is calculated
+	Then the basket price should be €<price>

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/ExternalDataFromJson.feature
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/ExternalDataFromJson.feature
@@ -23,15 +23,15 @@ Scenario: The basket price is calculated correctly for other products
 Scenario: The basket price is calculated correctly for products in nested products json
 	The scenario will be treated as a scenario outline with the examples from the json file.
 	The first object array is used by default from the json file.
-	Given the price of <product> is €<price>
+	Given the price of <product> is €<total price>
 	And the customer has put 1 pcs of <product> to the basket
 	When the basket price is calculated
-	Then the basket price should be €<price>
+	Then the basket price should be €<total price>
 
-@DataSource:products-nested-dataset.json @DataSet:products.ingredients
-Scenario: The basket price is calculated correctly for products.ingredients in nested products json
+@DataSource:products-nested-dataset.json @DataSet:products.varieties
+Scenario: The basket price is calculated correctly for products.varieties in nested products json
 	The scenario will be treated as a scenario outline with the examples from the json file.
-	The first object array is used by default from the json file.
+	The products.varieties is used from the json file.
 	Given the price of <product> is €<price>
 	And the customer has put 1 pcs of <product> to the basket
 	When the basket price is calculated

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products-nested-dataset.json
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products-nested-dataset.json
@@ -18,10 +18,10 @@
             ]
         },
         {
-           "product": "Apple",
-           "color": "red",
-           "total price": "2.5",
-           "varieties":
+            "product": "Apple",
+            "color": "red",
+            "total price": "2.5",
+            "varieties":
             [
                 {
                     "name": "Pink Lady",
@@ -34,10 +34,10 @@
            ]
         },
         {
-          "product": "Orange",
-          "color": "orange",
-          "total price": "2.9",
-          "varieties":
+            "product": "Orange",
+            "color": "orange",
+            "total price": "2.9",
+            "varieties":
             [
                 {
                     "name": "Seville Orange",

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products-nested-dataset.json
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products-nested-dataset.json
@@ -1,0 +1,45 @@
+﻿{
+    "products":
+    [
+        {
+           "product": "Chocolate",
+            "price": "2.5",
+            "color": "brown",
+            "ingredients":
+            [
+                {
+                    "name": "sugar",
+                    "value": "150mg"
+                },
+                {
+                    "name": "cacao",
+                    "value": "50mg"
+                }
+            ]
+        },
+        {
+          "product": "Apple",
+          "price": "1.0",
+          "color": "red",
+           "ingredients":
+            [
+                {
+                    "name": "sugar",
+                    "value": "70mg"
+                }
+            ]
+        },
+        {
+          "product": "Orange",
+          "price": "1.2",
+          "color": "orange",
+          "ingredients":
+            [
+                {
+                    "name": "sugar",
+                    "value": "50mg"
+                }
+            ]
+        }
+    ]
+}

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products-nested-dataset.json
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products-nested-dataset.json
@@ -2,44 +2,52 @@
     "products":
     [
         {
-           "product": "Chocolate",
-            "price": "2.5",
+            "product": "Chocolate",
             "color": "brown",
-            "ingredients":
+            "total price": "3.15",
+            "varieties":
             [
                 {
-                    "name": "sugar",
-                    "value": "150mg"
+                    "name": "Dark Chocolate",
+                    "price": "1.6"
                 },
                 {
-                    "name": "cacao",
-                    "value": "50mg"
+                    "name": "Milk Chocolate",
+                    "price": "1.55"
                 }
             ]
         },
         {
-          "product": "Apple",
-          "price": "1.0",
-          "color": "red",
-           "ingredients":
+           "product": "Apple",
+           "color": "red",
+           "total price": "2.5",
+           "varieties":
             [
                 {
-                    "name": "sugar",
-                    "value": "70mg"
+                    "name": "Pink Lady",
+                    "price": "1.0"
+                },
+                {
+                    "name": "Fuji",
+                    "price": "1.5"
                 }
-            ]
+           ]
         },
         {
           "product": "Orange",
-          "price": "1.2",
           "color": "orange",
-          "ingredients":
+          "total price": "2.9",
+          "varieties":
             [
                 {
-                    "name": "sugar",
-                    "value": "50mg"
+                    "name": "Seville Orange",
+                    "price": "1.3"
+                },
+                {
+                    "name": "Tangerine",
+                    "price": "1.6"
                 }
-            ]
+           ]
         }
     ]
 }

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products.json
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products.json
@@ -1,0 +1,33 @@
+﻿{
+    "products":
+    [
+        {
+            "product": "Chocolate",
+            "price": "2.5",
+            "color": "brown"
+        },
+        {
+            "product": "Apple",
+            "price": "1.0",
+            "color": "red"
+        },
+        {
+            "product": "Orange",
+            "price": "1.2",
+            "color": "orange"
+        }
+    ],
+     "other_products":
+    [
+        {
+            "product": "Cookie",
+            "price": "2.5",
+            "color": "brown"
+        },
+        {
+            "product": "Bananas",
+            "price": "1.0",
+            "color": "yellow"
+        }
+     ]
+}

--- a/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products.json
+++ b/Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/products.json
@@ -17,7 +17,7 @@
             "color": "orange"
         }
     ],
-     "other_products":
+    "other_products":
     [
         {
             "product": "Cookie",


### PR DESCRIPTION
The PR extends the External Data Plugin to support JSON files, analogous to added support for excel/csv in https://github.com/SpecFlowOSS/SpecFlow/pull/2429.

Code for handling the json is heavily based on https://github.com/kazantsev033/SpecFlow.Contrib.JsonData by @kazantsev033, but support was added for nested arrays of json objects.

The new concept is demonstrated by the /Plugins/SpecFlow.ExternalData/sample/ExternalDataSample/Features/ExternalDataFromJson.feature file.

Documentation to be updated (added text in bold):
@DataFormat:format - this only needs to be used if the format cannot be decided from the file extension. Currently we support CSV files (format 'CSV', extension .csv) and Excel files (format Excel, extensions .xlsx, .xls, .xlsb), **and JSON files (format 'JSON', extension.json)**.

@DataSet:data-set-name - used to select the worksheet of the Excel file (by default it uses the first one), **or to select the array of  objects in the json file (by default it uses the first object array)**. It is not used for CSV.

Checklist:
 
- [x]  I've added tests for my code. (most of the time mandatory)

- [ ]  I have added an entry to the changelog. (mandatory)

- [x]  My change requires a change to the documentation.

- [ ]  I have updated the documentation accordingly.