### PR TITLE
Read the EOL option from settings and pass it to the IndentProcessingWriter decorator.

### DIFF
--- a/SpecFlow.Tools.MsBuild.Generation/FeatureCodeBehindGenerator.cs
+++ b/SpecFlow.Tools.MsBuild.Generation/FeatureCodeBehindGenerator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using BoDi;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using TechTalk.SpecFlow.Configuration;
 using TechTalk.SpecFlow.Generator;
 using TechTalk.SpecFlow.Generator.Interfaces;
 using TechTalk.SpecFlow.Generator.Project;
@@ -14,10 +15,12 @@ namespace SpecFlow.Tools.MsBuild.Generation
     public class FeatureCodeBehindGenerator : IDisposable
     {
         private readonly ITestGenerator _testGenerator;
+        private readonly SpecFlowConfiguration _specFlowConfiguration;
 
-        public FeatureCodeBehindGenerator(ITestGenerator testGenerator)
+        public FeatureCodeBehindGenerator(ITestGenerator testGenerator, SpecFlowConfiguration specFlowConfiguration)
         {
             _testGenerator = testGenerator;
+            _specFlowConfiguration = specFlowConfiguration;
         }
 
         public TestFileGeneratorResult GenerateCodeBehindFile(string featureFile)
@@ -26,9 +29,23 @@ namespace SpecFlow.Tools.MsBuild.Generation
 
             var generatedFeatureFileName = Path.GetFileName(_testGenerator.GetTestFullPath(featureFileInput));
 
-            var testGeneratorResult = _testGenerator.GenerateTestFile(featureFileInput, new GenerationSettings());
+            var testGeneratorResult = _testGenerator.GenerateTestFile(featureFileInput, this.CreateGenerationSettings());
 
             return new TestFileGeneratorResult(testGeneratorResult, generatedFeatureFileName);
+        }
+
+        private GenerationSettings CreateGenerationSettings()
+        {
+            // ReSharper disable once ConvertTypeCheckPatternToNullCheck
+            if (this._specFlowConfiguration.EndOfLine is string eol)
+            {
+                return new GenerationSettings
+                {
+                    EndOfLine = eol
+                };
+            }
+            
+            return new GenerationSettings();
         }
 
         public void Dispose()

--- a/TechTalk.SpecFlow.Generator/IndentProcessingWriter.cs
+++ b/TechTalk.SpecFlow.Generator/IndentProcessingWriter.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using TechTalk.SpecFlow.Generator.Interfaces;
 
 namespace TechTalk.SpecFlow.Generator
 {
@@ -10,8 +11,9 @@ namespace TechTalk.SpecFlow.Generator
         TextWriter innerWriter;
         private bool trimSpaces = false;
 
-        public IndentProcessingWriter(TextWriter innerWriter)
+        public IndentProcessingWriter(TextWriter innerWriter, GenerationSettings generationSettings)
         {
+            this.CoreNewLine = generationSettings.EndOfLine.ToCharArray();
             this.innerWriter = innerWriter;
         }
 

--- a/TechTalk.SpecFlow.Generator/Interfaces/GenerationSettings.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/GenerationSettings.cs
@@ -29,9 +29,13 @@ namespace TechTalk.SpecFlow.Generator.Interfaces
         /// disabled by default.
         /// </summary>
         public bool WriteResultToFile { get; set; }
+        
+        public string EndOfLine { get; set; }
 
         public GenerationSettings()
         {
+            // INFO [minidfx 13.04.2023 08:38]: By default, we keep the platform EOL.
+            EndOfLine = Environment.NewLine;
             CheckUpToDate = false;
             UpToDateCheckingMethod = UpToDateCheckingMethod.ModificationTimeAndGeneratorVersion;
 

--- a/TechTalk.SpecFlow.Generator/TestGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/TestGenerator.cs
@@ -67,7 +67,7 @@ namespace TechTalk.SpecFlow.Generator
                     return new TestGeneratorResult(null, true);
             }
 
-            string generatedTestCode = GetGeneratedTestCode(featureFileInput);
+            string generatedTestCode = GetGeneratedTestCode(featureFileInput, settings);
             if(string.IsNullOrEmpty(generatedTestCode))
                 return new TestGeneratorResult(null, true);
 
@@ -86,9 +86,9 @@ namespace TechTalk.SpecFlow.Generator
             return new TestGeneratorResult(generatedTestCode, false);
         }
 
-        protected string GetGeneratedTestCode(FeatureFileInput featureFileInput)
+        protected string GetGeneratedTestCode(FeatureFileInput featureFileInput, GenerationSettings settings)
         {
-            using (var outputWriter = new IndentProcessingWriter(new StringWriter()))
+            using (var outputWriter = new IndentProcessingWriter(new StringWriter(), settings))
             {
                 var codeProvider = codeDomHelper.CreateCodeDomProvider();
                 var codeNamespace = GenerateTestFileCode(featureFileInput);

--- a/TechTalk.SpecFlow/Configuration/AppConfig/AppConfigConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/AppConfig/AppConfigConfigurationLoader.cs
@@ -28,6 +28,7 @@ namespace TechTalk.SpecFlow.Configuration.AppConfig
             List<string> additionalStepAssemblies = specFlowConfiguration.AdditionalStepAssemblies;
             ObsoleteBehavior obsoleteBehavior = specFlowConfiguration.ObsoleteBehavior;
             bool coloredOutput = specFlowConfiguration.ColoredOutput;
+            var eol = specFlowConfiguration.EndOfLine;
 
             bool allowRowTests = specFlowConfiguration.AllowRowTests;
             bool allowDebugGeneratedFiles = specFlowConfiguration.AllowDebugGeneratedFiles;
@@ -108,7 +109,8 @@ namespace TechTalk.SpecFlow.Configuration.AppConfig
                                             allowRowTests,
                                             addNonParallelizableMarkerForTags,
                                             obsoleteBehavior,
-                                            coloredOutput
+                                            coloredOutput,
+                                            eol
                                             );
         }
 

--- a/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
@@ -111,6 +111,8 @@ namespace TechTalk.SpecFlow.Configuration
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+            
+            traceListener.WriteToolOutput("'{0}' used as EOL.", specFlowConfiguration.EndOfLine.Replace("\r", "\\r").Replace("\n", "\\n"));
         }
 
 
@@ -133,7 +135,7 @@ namespace TechTalk.SpecFlow.Configuration
                 DefaultAddNonParallelizableMarkerForTags,
                 DefaultObsoleteBehavior,
                 DefaultColoredOutput
-                );
+            );
         }
 
 

--- a/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
@@ -54,6 +54,8 @@ namespace TechTalk.SpecFlow.Configuration
 
         public static bool DefaultColoredOutput => ConfigDefaults.ColoredOutput;
 
+        public static string DefaultEol => Environment.NewLine;
+
         public bool HasAppConfig => ConfigurationManager.GetSection("specFlow") != null;
 
         public bool HasJsonConfig
@@ -134,8 +136,9 @@ namespace TechTalk.SpecFlow.Configuration
                 DefaultAllowRowTests,
                 DefaultAddNonParallelizableMarkerForTags,
                 DefaultObsoleteBehavior,
-                DefaultColoredOutput
-            );
+                DefaultColoredOutput,
+                DefaultEol
+                );
         }
 
 

--- a/TechTalk.SpecFlow/Configuration/JsonConfig/GeneratorElement.cs
+++ b/TechTalk.SpecFlow/Configuration/JsonConfig/GeneratorElement.cs
@@ -19,5 +19,8 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
         //[JsonProperty("addNonParallelizableMarkerForTags", NullValueHandling = NullValueHandling.Ignore)]
         [DataMember(Name = "addNonParallelizableMarkerForTags")]
         public List<string> AddNonParallelizableMarkerForTags { get; set; }
+
+        [DataMember(Name = "endOfLine")]
+        public string EndOfLine { get; set; }
     }
 }

--- a/TechTalk.SpecFlow/Configuration/JsonConfig/JsonConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/JsonConfig/JsonConfigurationLoader.cs
@@ -87,6 +87,11 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
                 }
             }
 
+            if (TryParseEol(jsonConfig.Generator?.EndOfLine, out string endOfLine))
+            {
+                eol = endOfLine;
+            }
+
             return new SpecFlowConfiguration(
                 ConfigSource.Json,
                 containerRegistrationCollection,
@@ -106,6 +111,26 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
                 obsoleteBehavior,
                 coloredOutput
             );
+        }
+
+        private static bool TryParseEol(string rawEol, out string endOfLine)
+        {
+            switch (rawEol)
+            {
+                // INFO [minidfx 27.04.2023 08:20]: Windows platform 
+                case "\r\n": 
+                    endOfLine = "\r\n";
+                    return true;
+
+                // INFO [minidfx 27.04.2023 08:20]: Unix like platform
+                case "\n": 
+                    endOfLine = "\n";
+                    return true;
+            }
+
+            // INFO [minidfx 27.04.2023 08:24]: Use the current platform EOL by default
+            endOfLine = Environment.NewLine;
+            return false;
         }
     }
 }

--- a/TechTalk.SpecFlow/Configuration/JsonConfig/JsonConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/JsonConfig/JsonConfigurationLoader.cs
@@ -31,6 +31,7 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
             bool allowDebugGeneratedFiles = specFlowConfiguration.AllowDebugGeneratedFiles;
             var addNonParallelizableMarkerForTags = specFlowConfiguration.AddNonParallelizableMarkerForTags;
             var obsoleteBehavior = specFlowConfiguration.ObsoleteBehavior;
+            var eol = specFlowConfiguration.EndOfLine;
 
             if (jsonConfig.Language != null)
             {
@@ -109,7 +110,8 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
                 allowRowTests,
                 addNonParallelizableMarkerForTags,
                 obsoleteBehavior,
-                coloredOutput
+                coloredOutput,
+                eol
             );
         }
 

--- a/TechTalk.SpecFlow/Configuration/SpecFlowConfiguration.cs
+++ b/TechTalk.SpecFlow/Configuration/SpecFlowConfiguration.cs
@@ -32,7 +32,8 @@ namespace TechTalk.SpecFlow.Configuration
             bool allowRowTests,
             string[] addNonParallelizableMarkerForTags,
             ObsoleteBehavior obsoleteBehavior,
-            bool coloredOutput
+            bool coloredOutput,
+            string endOfLine
         )
         {
             ConfigSource = configSource;
@@ -52,6 +53,7 @@ namespace TechTalk.SpecFlow.Configuration
             AddNonParallelizableMarkerForTags = addNonParallelizableMarkerForTags;
             ObsoleteBehavior = obsoleteBehavior;
             ColoredOutput = coloredOutput;
+            EndOfLine = endOfLine;
         }
 
         public ConfigSource ConfigSource { get; set; }
@@ -72,9 +74,11 @@ namespace TechTalk.SpecFlow.Configuration
         public bool AllowDebugGeneratedFiles { get; set; }
         public bool AllowRowTests { get; set; }
         public string[] AddNonParallelizableMarkerForTags { get; set; }
+        public string EndOfLine { get; set; }
 
         //tracing settings
         public bool ColoredOutput { get; set; }
+
         public bool TraceSuccessfulSteps { get; set; }
         public bool TraceTimings { get; set; }
         public TimeSpan MinTracedDuration { get; set; }
@@ -97,7 +101,8 @@ namespace TechTalk.SpecFlow.Configuration
                                                               && MinTracedDuration.Equals(other.MinTracedDuration)
                                                               && StepDefinitionSkeletonStyle == other.StepDefinitionSkeletonStyle
                                                               && AdditionalStepAssemblies.SequenceEqual(other.AdditionalStepAssemblies)
-                                                              && AddNonParallelizableMarkerForTags.SequenceEqual(other.AddNonParallelizableMarkerForTags);
+                                                              && AddNonParallelizableMarkerForTags.SequenceEqual(other.AddNonParallelizableMarkerForTags)
+                                                              && EndOfLine == other.EndOfLine;
 
         public override bool Equals(object obj)
         {
@@ -139,6 +144,7 @@ namespace TechTalk.SpecFlow.Configuration
                 hashCode = (hashCode * 397) ^ (int)StepDefinitionSkeletonStyle;
                 hashCode = (hashCode * 397) ^ (AdditionalStepAssemblies != null ? AdditionalStepAssemblies.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (AddNonParallelizableMarkerForTags != null ? AddNonParallelizableMarkerForTags.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (EndOfLine != null ? EndOfLine.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorBasicsTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorBasicsTests.cs
@@ -15,11 +15,21 @@ namespace TechTalk.SpecFlow.GeneratorTests
     
     public class TestGeneratorBasicsTests : TestGeneratorTestsBase
     {
-        private string GenerateTestFromSimpleFeature(ProjectSettings projectSettings, string projectRelativeFolderPath = null)
+        private string GenerateTestFromSimpleFeature(ProjectSettings projectSettings,
+                                                     string projectRelativeFolderPath = null)
+        {
+            return this.GenerateTestFromSimpleFeature(projectSettings,
+                                                      defaultSettings,
+                                                      projectRelativeFolderPath);
+        }
+
+        private string GenerateTestFromSimpleFeature(ProjectSettings projectSettings,
+                                                     GenerationSettings generationSettings,
+                                                     string projectRelativeFolderPath = null)
         {
             var testGenerator = CreateTestGenerator(projectSettings);
 
-            var result = testGenerator.GenerateTestFile(CreateSimpleValidFeatureFileInput(projectRelativeFolderPath), defaultSettings);
+            var result = testGenerator.GenerateTestFile(CreateSimpleValidFeatureFileInput(projectRelativeFolderPath), generationSettings);
             result.Success.Should().Be(true);
             return result.GeneratedTestCode;
         }

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorBasicsTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorBasicsTests.cs
@@ -253,5 +253,37 @@ namespace TechTalk.SpecFlow.GeneratorTests
 
             folderPathArgument.Should().Be("\"Folder1/Folder2\"");
         }
+
+        [Fact]
+        public void Should_have_LF_as_EOL()
+        {
+            var generationSettingsHavingLFAsEol = new GenerationSettings
+            {
+                EndOfLine = "\n"
+            };
+            string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings,  generationSettingsHavingLFAsEol);
+
+            var lines = outputFile.Split(new []{ "\n" }, StringSplitOptions.None);
+            var firstLine = lines.First();
+            var expectedLine = "// ------------------------------------------------------------------------------";
+
+            Assert.Equal(expectedLine, firstLine);
+        }
+        
+        [Fact]
+        public void Should_have_CRLF_as_EOL()
+        {
+            var generationSettingsHavingCRLFAsEol = new GenerationSettings
+            {
+                EndOfLine = "\r\n"
+            };
+            string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings,  generationSettingsHavingCRLFAsEol);
+
+            var lines = outputFile.Split(new []{ "\r\n" }, StringSplitOptions.None);
+            var firstLine = lines.First();
+            var expectedLine = "// ------------------------------------------------------------------------------";
+
+            Assert.Equal(expectedLine, firstLine);
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/CultureInfoScopeTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/CultureInfoScopeTests.cs
@@ -51,7 +51,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
         {
             return new FeatureContext(default,
                                       new FeatureInfo(cultureInfo, default, default, default),
-                                      new SpecFlowConfiguration(default, default, default, default, cultureInfo, default, default, default, default, default, default, default, default, default, default, default, default));
+                                      new SpecFlowConfiguration(default, default, default, default, cultureInfo, default, default, default, default, default, default, default, default, default, default, default, default, default));
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Configuration/JsonConfigTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Configuration/JsonConfigTests.cs
@@ -433,6 +433,48 @@ namespace TechTalk.SpecFlow.RuntimeTests.Configuration
             var config = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), configAsJson);
             config.AddNonParallelizableMarkerForTags.Should().BeEquivalentTo("tag1", "tag2");
         }
+        
+        [Fact]
+        public void Check_Generator_EndOfLine_bad_value()
+        {
+            string configAsJson = @"{
+                                        ""generator"":
+                                        {
+                                            ""endOfLine"": ""a funny bad value""
+                                        }
+                                    }";
+
+            var config = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), configAsJson);
+            config.EndOfLine.Should().Be(Environment.NewLine);
+        }
+        
+        [Fact]
+        public void Check_Generator_EndOfLine_with_Windows_EOL()
+        {
+            string configAsJson = @"{
+                                        ""generator"":
+                                        {
+                                            ""endOfLine"": ""\r\n""
+                                        }
+                                    }";
+
+            var config = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), configAsJson);
+            config.EndOfLine.Should().Be("\r\n");
+        }
+        
+        [Fact]
+        public void Check_Generator_EndOfLine_with_Unix_like_EOL()
+        {
+            string configAsJson = @"{
+                                        ""generator"":
+                                        {
+                                            ""endOfLine"": ""\n""
+                                        }
+                                    }";
+
+            var config = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), configAsJson);
+            config.EndOfLine.Should().Be("\n");
+        }
 
         [Fact]
         public void Check_Defaults_Empty_Configuration()
@@ -492,6 +534,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Configuration
             //generator
             config.AllowDebugGeneratedFiles.Should().Be(ConfigDefaults.AllowDebugGeneratedFiles);
             config.AllowRowTests.Should().Be(ConfigDefaults.AllowRowTests);
+            config.EndOfLine.Should().Be(Environment.NewLine);
 
             //trace
             config.TraceTimings.Should().Be(ConfigDefaults.TraceTimings);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+4.1
+
+Features:
++ Give the opportunity to set the EOL of the generated files in the settings.json, helpful when you are working on the same project with different machines (Linux, Mac, Windows) avoiding to modify the generated files on each different kind of machine.
+
 4.0
 
 Breaking Changes:


### PR DESCRIPTION
This PR gives the opportunity to set the EOL of the code behind generated from the feature files. This is helpful for teams working on different operation system but on the same project by settings for instance CRLF as EOL even for the Mac/Linux users.

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
