### PR TITLE
DRAFT: xUnit Parallelize tests per scenario

### DIFF
--- a/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/ParallelTestMethodRunner.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/ParallelTestMethodRunner.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using Xunit;
+
+namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
+{
+    public class ParallelTestMethodRunner : XunitTestMethodRunner
+    {
+        readonly object[] constructorArguments;
+        readonly IMessageSink diagnosticMessageSink;
+
+        public ParallelTestMethodRunner(ITestMethod testMethod, IReflectionTypeInfo @class, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments)
+            : base(testMethod, @class, method, testCases, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource, constructorArguments)
+        {
+            this.constructorArguments = constructorArguments;
+            this.diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        // This method has been slightly modified from the original implementation to run tests in parallel
+        // https://github.com/xunit/xunit/blob/2.4.2/src/xunit.execution/Sdk/Frameworks/Runners/TestMethodRunner.cs#L130-L142
+        protected override async Task<RunSummary> RunTestCasesAsync()
+        {
+            var disableParallelization = TestMethod.TestClass.Class.GetCustomAttributes(typeof(CollectionAttribute)).Any()
+                || TestMethod.Method.GetCustomAttributes(typeof(MemberDataAttribute)).Any(a => a.GetNamedArgument<bool>(nameof(MemberDataAttribute.DisableDiscoveryEnumeration)));
+
+            if (disableParallelization)
+                return await base.RunTestCasesAsync().ConfigureAwait(false);
+
+            var summary = new RunSummary();
+
+            var caseTasks = TestCases.Select(RunTestCaseAsync);
+            var caseSummaries = await Task.WhenAll(caseTasks).ConfigureAwait(false);
+
+            foreach (var caseSummary in caseSummaries)
+            {
+                summary.Aggregate(caseSummary);
+            }
+
+            return summary;
+        }
+
+        protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+        {
+            // Create a new TestOutputHelper for each test case since they cannot be reused when running in parallel
+            var args = constructorArguments.Select(a => a is TestOutputHelper ? new TestOutputHelper() : a).ToArray();
+
+            var action = () => testCase.RunAsync(diagnosticMessageSink, MessageBus, args, new ExceptionAggregator(Aggregator), CancellationTokenSource);
+
+            // Respect MaxParallelThreads by using the MaxConcurrencySyncContext if it exists, mimicking how collections are run
+            // https://github.com/xunit/xunit/blob/2.4.2/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs#L169-L176
+            if (SynchronizationContext.Current != null)
+            {
+                var scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+                return await Task.Factory.StartNew(action, CancellationTokenSource.Token, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler, scheduler).Unwrap().ConfigureAwait(false);
+            }
+
+            return await Task.Run(action, CancellationTokenSource.Token).ConfigureAwait(false);
+        }
+    }
+}

--- a/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/ParallelTestRunner.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/ParallelTestRunner.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using Xunit;
+
+namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
+{
+    public class ParallelTestClassRunner : XunitTestClassRunner
+    {
+        public ParallelTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings)
+            : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+        {
+        }
+
+        // This method has been slightly modified from the original implementation to run tests in parallel
+        // https://github.com/xunit/xunit/blob/2.4.2/src/xunit.execution/Sdk/Frameworks/Runners/TestClassRunner.cs#L194-L219
+        protected override async Task<RunSummary> RunTestMethodsAsync()
+        {
+            var disableParallelization = TestClass.Class.GetCustomAttributes(typeof(CollectionAttribute)).Any();
+
+            if (disableParallelization)
+                return await base.RunTestMethodsAsync().ConfigureAwait(false);
+
+            var summary = new RunSummary();
+            IEnumerable<IXunitTestCase> orderedTestCases;
+            try
+            {
+                orderedTestCases = TestCaseOrderer.OrderTestCases(TestCases);
+            }
+            catch (Exception ex)
+            {
+                var innerEx = Unwrap(ex);
+                DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Test case orderer '{TestCaseOrderer.GetType().FullName}' threw '{innerEx.GetType().FullName}' during ordering: {innerEx.Message}{Environment.NewLine}{innerEx.StackTrace}"));
+                orderedTestCases = TestCases.ToList();
+            }
+
+            var constructorArguments = CreateTestClassConstructorArguments();
+            var methodGroups = orderedTestCases.GroupBy(tc => tc.TestMethod, TestMethodComparer.Instance);
+            var methodTasks = methodGroups.Select(m => RunTestMethodAsync(m.Key, (IReflectionMethodInfo)m.Key.Method, m, constructorArguments));
+            var methodSummaries = await Task.WhenAll(methodTasks).ConfigureAwait(false);
+
+            foreach (var methodSummary in methodSummaries)
+            {
+                summary.Aggregate(methodSummary);
+            }
+
+            return summary;
+        }
+
+        protected override Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, object[] constructorArguments)
+            => new ParallelTestMethodRunner(testMethod, Class, method, testCases, DiagnosticMessageSink, MessageBus, new ExceptionAggregator(Aggregator), CancellationTokenSource, constructorArguments).RunAsync();
+
+        private static Exception Unwrap(Exception ex)
+        {
+            while (true)
+            {
+                if (ex is not TargetInvocationException tiex || tiex.InnerException == null)
+                    return ex;
+
+                ex = tiex.InnerException;
+            }
+        }
+    }
+}

--- a/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/XunitTestCollectionRunnerWithAssemblyFixture.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/XunitTestCollectionRunnerWithAssemblyFixture.cs
@@ -48,7 +48,7 @@ namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
             }
 
             // We've done everything we need, so let the built-in types do the rest of the heavy lifting
-            return new XunitTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, combinedFixtures).RunAsync();
+            return new ParallelTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, combinedFixtures).RunAsync();
         }
     }
 }


### PR DESCRIPTION
Hello 👋

This PR is mainly to start a discussion and provide a small PoC on how [this idea](https://support.specflow.org/hc/en-us/community/posts/11191021488797--SpecFlow-xUnit-Add-a-possibility-to-parallelize-tests-per-scenario-by-reassigning-all-test-cases-to-a-new-collection) might be implemented.

The classes are taken and modified slightly from [this excellent xUnit plugin](https://github.com/meziantou/Meziantou.Xunit.ParallelTestFramework).

## Some of the questions/thoughts I had

* This PR has everything parallel by scenario unless a collection is specified using a collection attribute. Should we have this opt-in instead so it's non-breaking? I want to enable it globally somehow if it's opt-in.
* I flagged this as breaking because people may have their dependency injection set up to share data between test scenarios, or they may be expecting their scenarios to be running in sequential order within a feature; this would change that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
