### PR TITLE
Added order parameter to stepArgumentTransformation to prioritize execution

### DIFF
--- a/TechTalk.SpecFlow/Bindings/BindingFactory.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingFactory.cs
@@ -30,8 +30,8 @@ public class BindingFactory : IBindingFactory
     }
 
     public IStepArgumentTransformationBinding CreateStepArgumentTransformation(string regexString,
-        IBindingMethod bindingMethod, string parameterTypeName = null)
+        IBindingMethod bindingMethod, string parameterTypeName = null, int order = default)
     {
-        return new StepArgumentTransformationBinding(regexString, bindingMethod, parameterTypeName);
+        return new StepArgumentTransformationBinding(regexString, bindingMethod, parameterTypeName, order);
     }
 }

--- a/TechTalk.SpecFlow/Bindings/BindingRegistry.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingRegistry.cs
@@ -46,7 +46,7 @@ namespace TechTalk.SpecFlow.Bindings
 
         public virtual IEnumerable<IStepArgumentTransformationBinding> GetStepTransformations()
         {
-            return _stepArgumentTransformations;
+            return _stepArgumentTransformations.OrderBy(s => s.Order);
         }
 
         public IEnumerable<BindingError> GetErrorMessages()

--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
@@ -199,6 +199,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         {
             string regex = stepArgumentTransformationAttribute.TryGetAttributeValue<string>(0) ?? stepArgumentTransformationAttribute.TryGetAttributeValue<string>(nameof(StepArgumentTransformationAttribute.Regex));
             string name = stepArgumentTransformationAttribute.TryGetAttributeValue<string>(nameof(StepArgumentTransformationAttribute.Name));
+            int order = stepArgumentTransformationAttribute.TryGetAttributeValue<int>(nameof(StepArgumentTransformationAttribute.Order));
 
             var validationResult = ValidateStepArgumentTransformation(bindingSourceMethod, stepArgumentTransformationAttribute);
             if (!validationResult.IsValid)
@@ -207,7 +208,7 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
                 return;
             }
 
-            var stepArgumentTransformationBinding = _bindingFactory.CreateStepArgumentTransformation(regex, bindingSourceMethod.BindingMethod, name);
+            var stepArgumentTransformationBinding = _bindingFactory.CreateStepArgumentTransformation(regex, bindingSourceMethod.BindingMethod, name, order);
 
             ProcessStepArgumentTransformationBinding(stepArgumentTransformationBinding);
         }

--- a/TechTalk.SpecFlow/Bindings/IBindingFactory.cs
+++ b/TechTalk.SpecFlow/Bindings/IBindingFactory.cs
@@ -11,6 +11,6 @@ namespace TechTalk.SpecFlow.Bindings
             BindingScope bindingScope, string expressionString);
 
         IStepArgumentTransformationBinding CreateStepArgumentTransformation(string regexString,
-            IBindingMethod bindingMethod, string parameterTypeName = null);
+            IBindingMethod bindingMethod, string parameterTypeName = null, int order = default);
     }
 }

--- a/TechTalk.SpecFlow/Bindings/IStepArgumentTransformationBinding.cs
+++ b/TechTalk.SpecFlow/Bindings/IStepArgumentTransformationBinding.cs
@@ -16,5 +16,10 @@ namespace TechTalk.SpecFlow.Bindings
         /// The regular expression matches the step argument. Optional, if null, the transformation receives the entire argument.
         /// </summary>
         Regex Regex { get; }
+        
+        /// <summary>
+        /// The deterministic order for step argument transformation
+        /// </summary>
+        int Order { get; }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/StepArgumentTransformationBinding.cs
+++ b/TechTalk.SpecFlow/Bindings/StepArgumentTransformationBinding.cs
@@ -8,16 +8,19 @@ namespace TechTalk.SpecFlow.Bindings
         public string Name { get; }
 
         public Regex Regex { get; }
+        
+        public int Order { get; }
 
-        public StepArgumentTransformationBinding(Regex regex, IBindingMethod bindingMethod, string name = null)
+        public StepArgumentTransformationBinding(Regex regex, IBindingMethod bindingMethod, string name = null, int order = default)
             : base(bindingMethod)
         {
             Regex = regex;
             Name = name;
+            Order = order;
         }
 
-        public StepArgumentTransformationBinding(string regexString, IBindingMethod bindingMethod, string name = null)
-            : this(CreateRegexOrNull(regexString), bindingMethod, name)
+        public StepArgumentTransformationBinding(string regexString, IBindingMethod bindingMethod, string name = null, int order = default)
+            : this(CreateRegexOrNull(regexString), bindingMethod, name, order)
         {
         }
 

--- a/TechTalk.SpecFlow/Bindings/StepArgumentTypeConverter.cs
+++ b/TechTalk.SpecFlow/Bindings/StepArgumentTypeConverter.cs
@@ -29,13 +29,18 @@ namespace TechTalk.SpecFlow.Bindings
         protected virtual IStepArgumentTransformationBinding GetMatchingStepTransformation(object value, IBindingType typeToConvertTo, bool traceWarning)
         {
             var stepTransformations = bindingRegistry.GetStepTransformations().Where(t => CanConvert(t, value, typeToConvertTo)).ToArray();
-            if (stepTransformations.Length > 1 && traceWarning)
+            if (traceWarning && HasMultipleTransformationsWithSameOrder(stepTransformations))
             {
                 testTracer.TraceWarning($"Multiple step transformation matches to the input ({value}, target type: {typeToConvertTo}). We use the first.");
             }
 
             return stepTransformations.Length > 0 ? stepTransformations[0] : null;
         }
+
+        private bool HasMultipleTransformationsWithSameOrder(IStepArgumentTransformationBinding[] transformations) =>
+            transformations
+                .GroupBy(t => t.Order)
+                .Any(group => group.Count() > 1);
 
         public async Task<object> ConvertAsync(object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
         {

--- a/TechTalk.SpecFlow/StepArgumentTransformationAttribute.cs
+++ b/TechTalk.SpecFlow/StepArgumentTransformationAttribute.cs
@@ -17,9 +17,17 @@ namespace TechTalk.SpecFlow
         /// </summary>
         public string Name { get; set; }
 
-        public StepArgumentTransformationAttribute(string regex)
+        /// <summary>
+        /// Specifies the deterministic order for step argument transformations. Lower numbers have higher priority.
+        /// Before .NET 7, step argument transformations with the same priority will execute in a non-deterministic order.
+        /// Default value is 0.
+        /// </summary>
+        public int Order { get; set; }
+
+        public StepArgumentTransformationAttribute(string regex, int order = default)
         {
             Regex = regex;
+            Order = order;
         }
 
         public StepArgumentTransformationAttribute()

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingRegistryTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/BindingRegistryTests.cs
@@ -40,5 +40,25 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
 
             result.Should().BeEquivalentTo(new List<HookBinding> { hook1, hook2 });
         }
+        
+        [Fact]
+        public void GetStepTransformations_should_return_all_step_transformers_in_correct_order()
+        {
+            var sut = new BindingRegistry();
+
+            var sat1 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object);
+            var sat2 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object);
+            var sat3 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object, order: 1);
+            var sat4 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object, null, 2);
+
+            sut.RegisterStepArgumentTransformationBinding(sat4);
+            sut.RegisterStepArgumentTransformationBinding(sat1);
+            sut.RegisterStepArgumentTransformationBinding(sat3);
+            sut.RegisterStepArgumentTransformationBinding(sat2);
+
+            var result = sut.GetStepTransformations();
+
+            result.Should().BeEquivalentTo(new List<StepArgumentTransformationBinding> { sat1, sat2, sat3, sat4 });
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -18,10 +18,28 @@ namespace TechTalk.SpecFlow.RuntimeTests
         [Binding]
         public class StepTransformationExample
         {
-            [StepArgumentTransformation("BindingRegistryTests")]
-            public int Transform(string val)
+            [StepArgumentTransformation("prop1 .*")]
+            public int TransformProperty1(string val)
             {
                 return 42;
+            }
+            
+            [StepArgumentTransformation(Regex="prop2 .*")]
+            public int TransformProperty2(string val)
+            {
+                return 43;
+            }
+            
+            [StepArgumentTransformation(Regex="prop3 .*", Order = 5)]
+            public int TransformProperty3(string val)
+            {
+                return 44;
+            }
+            
+            [StepArgumentTransformation(Order = 10)]
+            public int TransformGlobal(string val)
+            {
+                return 45;
             }
         }
 
@@ -287,6 +305,34 @@ namespace TechTalk.SpecFlow.RuntimeTests
                     s =>
                         s.HookType == HookType.AfterTestRun && s.Method.Name == "AfterOrderTenThousandAnd4" &&
                         s.HookOrder == 10004));
+        }
+        
+         [Fact]
+        public void ShouldFindStepArgumentTransformations_WithSpecifiedOrder()
+        {
+            var builder = new RuntimeBindingRegistryBuilder(bindingSourceProcessorStub, new SpecFlowAttributesFilter());
+
+            BuildCompleteBindingFromType(builder, typeof (StepTransformationExample));
+
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty1) && sat.Order == default);
+            
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty2) && sat.Order == default);
+            
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty3) && sat.Order == 5);
+            
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformGlobal) && sat.Order == 10);
         }
 
         [Fact]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/StepArgumentTransformationTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/StepArgumentTransformationTests.cs
@@ -79,14 +79,14 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
     }
 
-    public class StepTransformationTests
+    public class StepArgumentTransformationTests
     {
         private readonly Mock<IBindingRegistry> bindingRegistryStub = new Mock<IBindingRegistry>();
         private readonly Mock<IContextManager> contextManagerStub = new Mock<IContextManager>();
         private readonly Mock<IAsyncBindingInvoker> methodBindingInvokerStub = new Mock<IAsyncBindingInvoker>();
         private readonly List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
 
-        public StepTransformationTests()
+        public StepArgumentTransformationTests()
         {
             // ScenarioContext is needed, because the [Binding]-instances live there
             var scenarioContext = new ScenarioContext(new ObjectContainer(), null, new TestObjectResolver());

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/StepArgumentTypeConverterTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/StepArgumentTypeConverterTest.cs
@@ -1,32 +1,34 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Xunit;
 using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Bindings.Reflection;
 using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Tracing;
 
 namespace TechTalk.SpecFlow.RuntimeTests
 {
-    
     public class StepArgumentTypeConverterTests
     {
-        private IStepArgumentTypeConverter _stepArgumentTypeConverter;
-        private readonly Mock<IAsyncBindingInvoker> methodBindingInvokerStub = new Mock<IAsyncBindingInvoker>();
-        private CultureInfo _enUSCulture;
+        private readonly Mock<ITestTracer> _testTracer;
+        private readonly List<IStepArgumentTransformationBinding> _stepTransformations;
+        private readonly IStepArgumentTypeConverter _stepArgumentTypeConverter;
+        private readonly Mock<IAsyncBindingInvoker> methodBindingInvokerStub = new();
+        private readonly CultureInfo _enUSCulture;
 
         public StepArgumentTypeConverterTests()
         {
             Mock<IBindingRegistry> bindingRegistryStub = new Mock<IBindingRegistry>();
-            List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
-            bindingRegistryStub.Setup(br => br.GetStepTransformations()).Returns(stepTransformations);
+            _stepTransformations = new List<IStepArgumentTransformationBinding>();
+            bindingRegistryStub.Setup(br => br.GetStepTransformations()).Returns(_stepTransformations);
+            _testTracer = new Mock<ITestTracer>();
 
-            _stepArgumentTypeConverter = new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, new Mock<IContextManager>().Object, methodBindingInvokerStub.Object);
+            _stepArgumentTypeConverter = new StepArgumentTypeConverter(_testTracer.Object, bindingRegistryStub.Object, new Mock<IContextManager>().Object, methodBindingInvokerStub.Object);
             _enUSCulture = new CultureInfo("en-US", false);
         }
 
@@ -121,6 +123,31 @@ namespace TechTalk.SpecFlow.RuntimeTests
             result.As<TestClass>().Time.Should().Be(originalValue);
         }
 
+        [Fact]
+        public async Task ShouldTraceWarningIfMultipleTransformationsFound()
+        {
+            var method = typeof(TestClass).GetMethod(nameof(TestClass.StringToIntConverter));
+            _stepTransformations.Add(new StepArgumentTransformationBinding(@"\d+", new RuntimeBindingMethod(method)));
+            _stepTransformations.Add(new StepArgumentTransformationBinding(@".*", new RuntimeBindingMethod(method)));
+            
+            await _stepArgumentTypeConverter.ConvertAsync("1", typeof(int), _enUSCulture);
+            
+            _testTracer.Verify(c => c.TraceWarning(It.IsAny<string>()), Times.Once);
+        }
+        
+        [Fact]
+        public async Task ShouldNotTraceWarningIfTransformationsHaveDifferentOrder()
+        {
+            var method = typeof(TestClass).GetMethod(nameof(TestClass.StringToIntConverter));
+
+            _stepTransformations.Add(new StepArgumentTransformationBinding(@"\d+", new RuntimeBindingMethod(method)));
+            _stepTransformations.Add(new StepArgumentTransformationBinding(@".*", new RuntimeBindingMethod(method), order: 10));
+            
+            await _stepArgumentTypeConverter.ConvertAsync("1", typeof(int), _enUSCulture);
+            
+            _testTracer.Verify(c => c.TraceWarning(It.IsAny<string>()), Times.Never);
+        }
+
         [TypeConverter(typeof(TessClassTypeConverter))]
         class TestClass
         {
@@ -138,8 +165,9 @@ namespace TechTalk.SpecFlow.RuntimeTests
                     return new TestClass { Time = (DateTimeOffset) value };
                 }
             }
-        }
 
-   
+            [StepArgumentTransformation]
+            public int StringToIntConverter(string value) => int.Parse(value);
+        }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ Breaking Changes:
 + Removed the ability to call steps from steps via string - https://github.com/SpecFlowOSS/SpecFlow/issues/1733
 + Removed .NET Core 2.1 support (min .NET Core version: 3.1)
 + Removed .NET Framework 4.6.1 support (min .NET Framework version: 4.6.2)
-+ Bindigns declared as 'async void' are not allowed. Use 'async Task' instead.
++ Bindings declared as 'async void' are not allowed. Use 'async Task' instead.
 
 Features:
 + Add an option to colorize test result output
@@ -14,6 +14,7 @@ Features:
 + Support for ValueTask and ValueTask<T> binding methods (step definitions, hooks, step argument transformations)
 + Rules now support Background blocks
 + Collect binding errors (type load, binding, step definition) and report them as exception when any of the tests are executed.
++ Support 'Order' parameter for `StepArgumentTransformationAttribute` to prioritize execution
 
 Changes:
 + Existing step definition expressions detected to be either regular or cucumber expression. Check https://docs.specflow.org/projects/specflow/en/latest/Guides/UpgradeSpecFlow3To4.html for potential upgrade issues.

--- a/docs/Bindings/Step-Argument-Conversions.md
+++ b/docs/Bindings/Step-Argument-Conversions.md
@@ -17,7 +17,7 @@ A step argument transformation is used to convert an argument if:
 * The return type of the transformation is the same as the parameter type
 * The regular expression (if specified) matches the original (string) argument
 
-**Note:** If multiple matching transformation are available, a warning is output in the trace and the first transformation is used.
+**Note:** If multiple matching transformations are available and no order is specified, a warning is output in the trace and the first transformation is used. If the order is specified, the transformation with the lowest order value is used.
 
 The following example transforms a relative period of time (`in 3 days`) into a `DateTime` structure.
 
@@ -73,6 +73,31 @@ public class Transforms
     string chave = nfe.Tab();
     Assert.IsNotNull(chave);
   }
+}
+```
+
+The following example transforms a string argument to a Rating model. If regex matches the expression, the given rating score will be parsed. Otherwise, the default rating will be used.
+
+```c#
+[Binding]
+public class Transforms
+{
+    [StepArgumentTransformation(@"with (\d+) score")]
+    public Rating RatingTransformation(int score)
+    {
+      return new Rating(score);
+    }
+    
+    [StepArgumentTransformation(Order = 10)]
+    public Rating GlobalRatingTransformation(string input) 
+    {
+        return Rating.DefaultRating;
+    }
+}
+
+public record Rating(int Value) 
+{
+    public static Rating DefaultRating => new Rating(50);
 }
 ```
 


### PR DESCRIPTION
### What's changed

* Added an optional `Order` parameter for `StepArgumentTransformation` to prioritize global type handlers effectively, ensuring they're considered last when needed.
* Renamed `StepTransformationTests` file to `StepArgumentTransformationTests` as this change should've be done with [this commit](https://github.com/SpecFlowOSS/SpecFlow/commit/63181711bc88437ef2d97bff4b7482a4e4982509)

---

> In .NET 6 and earlier versions, the [GetMethods](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethods?view=net-8.0) method does not return methods in a particular order, such as alphabetical or declaration order. Your code must not depend on the order in which methods are returned, because that order varies. However, starting with .NET 7, the ordering is deterministic based upon the metadata ordering in the assembly.

[(source)](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethods?view=net-8.0)

`Type.GetMethods` is used to find all `StepArgumentTransformation` functions, but the order is not deterministic before .NET 7. This inconsistency made it tricky to handle type transformations, especially when setting up global handlers for optional parameters.

## Types of changes

- [x] New feature (non-breaking change which adds functionality).
- [x] Other (docs, build config, etc)

## Checklist:

- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
