### PR TITLE
feat(value-retrievers): add DateOnly value retriever

### DIFF
--- a/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueRetrieverList.cs
+++ b/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueRetrieverList.cs
@@ -30,7 +30,10 @@ namespace TechTalk.SpecFlow.Assist
                 new DecimalValueRetriever(),
                 new CharValueRetriever(),
                 new DateTimeOffsetValueRetriever(),
-                new UriValueRetriever()
+                new UriValueRetriever(),
+#if NET6_0_OR_GREATER
+                new DateOnlyValueRetriever()
+#endif
             }, false)
         {
         }

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DateOnlyValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DateOnlyValueRetriever.cs
@@ -1,0 +1,21 @@
+﻿#if NET6_0_OR_GREATER
+using System.Globalization;
+using System;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+public class DateOnlyValueRetriever : StructRetriever<DateOnly>
+{
+    /// <summary>
+    /// Gets or sets the DateTimeStyles to use when parsing the string value.
+    /// </summary>
+    /// <remarks>Defaults to DateTimeStyles.None.</remarks>
+    public static DateTimeStyles DateTimeStyles { get; set; } = DateTimeStyles.None;
+
+    protected override DateOnly GetNonEmptyValue(string value)
+    {
+        DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles, out DateTime dateTimeValue);
+        return DateOnly.FromDateTime(dateTimeValue);
+    }
+}
+#endif

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -61,6 +61,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 
                 typeof(ArrayValueRetriever),
                 typeof(ListValueRetriever),
+#if NET6_0_OR_GREATER
+                typeof(DateOnlyValueRetriever),
+#endif
             };
 
             var service = new Service();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateOnlyValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateOnlyValueRetrieverTests.cs
@@ -1,0 +1,92 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Xunit;
+using FluentAssertions;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    public class DateOnlyValueRetrieverTests
+    {
+        private const string IrrelevantKey = "Irrelevant";
+        private readonly Type IrrelevantType = typeof(object);
+
+        public DateOnlyValueRetrieverTests()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+        }
+
+        [Theory]
+        [InlineData(typeof(DateOnly), true)]
+        [InlineData(typeof(DateOnly?), true)]
+        [InlineData(typeof(int), false)]
+        public void CanRetrieve(Type type, bool expectation)
+        {
+            var retriever = new DateOnlyValueRetriever();
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(IrrelevantKey, IrrelevantKey), IrrelevantType, type);
+            result.Should().Be(expectation);
+        }
+
+        private void Retrieve_correct_value(string value, DateOnly expectation)
+        {
+            var retriever = new DateOnlyValueRetriever();
+            var result = (DateOnly)retriever.Retrieve(new KeyValuePair<string, string>(IrrelevantKey, value), IrrelevantType, typeof(DateOnly));
+            result.Should().Be(expectation);
+        }
+
+        private void Retrieve_correct_nullable_value(string value, DateOnly? expectation)
+        {
+            var retriever = new DateOnlyValueRetriever();
+            var result = (DateOnly?)retriever.Retrieve(new KeyValuePair<string, string>(IrrelevantKey, value), IrrelevantType, typeof(DateOnly?));
+            result.Should().Be(expectation);
+        }
+
+        [Fact]
+        public void Returns_MinValue_when_the_value_is_null()
+        {
+            Retrieve_correct_value(null, DateOnly.MinValue);
+        }
+
+        [Fact]
+        public void Returns_null_when_the_value_is_null_and_type_nullable()
+        {
+            Retrieve_correct_nullable_value(null, null);
+        }
+
+        [Fact]
+        public void Returns_MinValue_when_the_value_is_empty()
+        {
+            Retrieve_correct_value(string.Empty, DateOnly.MinValue);
+        }
+
+        [Fact]
+        public void Returns_null_when_the_value_is_empty_and_type_nullable()
+        {
+            Retrieve_correct_nullable_value(string.Empty, null);
+        }
+
+        [Fact]
+        public void Returns_the_date_when_value_represents_a_valid_date()
+        {
+            Retrieve_correct_value("1/1/2011", new DateOnly(2011, 1, 1));
+            Retrieve_correct_nullable_value("1/1/2011", new DateOnly(2011, 1, 1));
+            Retrieve_correct_value("12/31/2015", new DateOnly(2015, 12, 31));
+            Retrieve_correct_nullable_value("12/31/2015", new DateOnly(2015, 12, 31));
+        }
+
+        [Fact]
+        public void Returns_MinValue_when_the_value_is_not_a_valid_dateonly()
+        {
+            Retrieve_correct_value("xxxx", DateOnly.MinValue);
+            Retrieve_correct_nullable_value("xxxx", DateOnly.MinValue);
+            Retrieve_correct_value("this is not a date", DateOnly.MinValue);
+            Retrieve_correct_nullable_value("this is not a date", DateOnly.MinValue);
+            Retrieve_correct_value("Thursday", DateOnly.MinValue);
+            Retrieve_correct_nullable_value("Thursday", DateOnly.MinValue);
+        }
+    }
+}
+#endif

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Features:
 + Support for ValueTask and ValueTask<T> binding methods (step definitions, hooks, step argument transformations)
 + Rules now support Background blocks
 + Collect binding errors (type load, binding, step definition) and report them as exception when any of the tests are executed.
++ Support for DateOnly types.
 
 Changes:
 + Existing step definition expressions detected to be either regular or cucumber expression. Check https://docs.specflow.org/projects/specflow/en/latest/Guides/UpgradeSpecFlow3To4.html for potential upgrade issues.


### PR DESCRIPTION
Add the DateOnly value retriever, starting from NET6

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

Support for DateOnly type starting from NET6.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
